### PR TITLE
Fix Wrong Oriented Cell When Calling SlabGenerator.get_slab

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -2558,6 +2558,7 @@ class IStructure(SiteCollection, MSONable):
         tolerance: float = 0.25,
         use_site_props: bool = False,
         constrain_latt: list | dict | None = None,
+        reduce: bool = True,
     ) -> Self | Structure:
         """Find a smaller unit cell than the input. Sometimes it doesn't
         find the smallest possible one, so this method is recursively called
@@ -2577,6 +2578,8 @@ class IStructure(SiteCollection, MSONable):
                 preserve, e.g. ["alpha", "c"] or dict with the lattice
                 parameter names as keys and values we want the parameters to
                 be e.g. {"alpha": 90, "c": 2.5}.
+            reduce (bool): Whether get_reduced_structure is called prior to
+                checking lattice constraints and returning structure.
 
         Returns:
             The most primitive structure found.
@@ -2745,7 +2748,9 @@ class IStructure(SiteCollection, MSONable):
                         tolerance=tolerance,
                         use_site_props=use_site_props,
                         constrain_latt=constrain_latt,
-                    ).get_reduced_structure()
+                    )
+                    if reduce:
+                        primitive = primitive.get_reduced_structure()
                     if not constrain_latt:
                         return primitive
 

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -133,7 +133,6 @@ class Slab(Structure):
                 fractional_coords. Defaults to None for no properties.
             energy (float): A value for the energy.
         """
-        self.oriented_unit_cell = oriented_unit_cell
         self.miller_index = miller_index
         self.shift = shift
         self.reconstruction = reconstruction
@@ -153,6 +152,30 @@ class Slab(Structure):
                 lattice.beta,
                 lattice.gamma,
             )
+
+            oriented_unit_cell = copy.deepcopy(oriented_unit_cell)
+            ouc_lattice = oriented_unit_cell.lattice
+            ouc_lattice = Lattice.from_parameters(
+                ouc_lattice.a,
+                ouc_lattice.b,
+                ouc_lattice.c,
+                ouc_lattice.alpha,
+                ouc_lattice.beta,
+                ouc_lattice.gamma,
+            )
+
+            self.oriented_unit_cell = Structure(
+                ouc_lattice,
+                oriented_unit_cell.species,
+                oriented_unit_cell.frac_coords,
+                charge=oriented_unit_cell.charge,
+                coords_are_cartesian=False,
+                site_properties=oriented_unit_cell.site_properties,
+                labels=oriented_unit_cell.labels,
+                properties=oriented_unit_cell.properties,
+            )
+        else:
+            self.oriented_unit_cell = oriented_unit_cell
 
         super().__init__(
             lattice,
@@ -1152,31 +1175,35 @@ class SlabGenerator:
         if self.center_slab:
             struct = center_slab(struct)
 
+        ouc = self.oriented_unit_cell.copy()
+
         # Reduce to primitive cell
         if self.primitive:
-            prim_slab = struct.get_primitive_structure(tolerance=tol)
-            struct = prim_slab
+            prim_slab = struct.get_primitive_structure(tolerance=tol, reduce=False)
 
             if energy is not None:
                 energy *= prim_slab.volume / struct.volume
 
-        # Reorient the lattice to get the correctly reduced cell
-        ouc = self.oriented_unit_cell.copy()
-        if self.primitive:
             # Find a reduced OUC
-            slab_l = struct.lattice
-            ouc = ouc.get_primitive_structure(
+            prim_slab_l = prim_slab.lattice
+            prim_ouc = ouc.get_primitive_structure(
                 constrain_latt={
-                    "a": slab_l.a,
-                    "b": slab_l.b,
-                    "alpha": slab_l.alpha,
-                    "beta": slab_l.beta,
-                    "gamma": slab_l.gamma,
-                }
+                    "a": prim_slab_l.a,
+                    "b": prim_slab_l.b,
+                    "alpha": prim_slab_l.alpha,
+                    "beta": prim_slab_l.beta,
+                    "gamma": prim_slab_l.gamma,
+                },
+                reduce=False,
             )
 
-            # Ensure lattice a and b are consistent between the OUC and the Slab
-            ouc = ouc if (slab_l.a == ouc.lattice.a and slab_l.b == ouc.lattice.b) else self.oriented_unit_cell
+            # Ensure lattice a and b are consistent between the OUC and the slab
+            a_b_consistent = np.isclose(prim_slab_l.a, prim_ouc.lattice.a) and np.isclose(
+                prim_slab_l.b, prim_ouc.lattice.b
+            )
+            if a_b_consistent:
+                struct = prim_slab
+                ouc = prim_ouc
 
         return Slab(
             struct.lattice,

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -436,6 +436,32 @@ class TestSlabGenerator(MatSciTest):
             assert np.dot(a_vec, gen._normal) == approx(0)
             assert np.dot(b_vec, gen._normal) == approx(0)
 
+    def test_get_slab_oriented_unit_cell_obeys_constrained_lattice(self):
+        bulk = Structure.from_spacegroup(
+            "Fm-3m",
+            Lattice.cubic(4.194),
+            ["Mg", "O"],
+            [[0, 0, 0], [0.5, 0.5, 0.5]],
+        )
+        slab = SlabGenerator(
+            initial_structure=bulk,
+            miller_index=(1, 1, 1),
+            min_slab_size=10,
+            min_vacuum_size=20,
+            primitive=True,
+            lll_reduce=False,
+            center_slab=False,
+            max_normal_search=None,
+        ).get_slab(shift=0)
+
+        slab_l = slab.lattice
+        ouc_l = slab.oriented_unit_cell.lattice
+        assert ouc_l.a == approx(slab_l.a)
+        assert ouc_l.b == approx(slab_l.b)
+        assert ouc_l.alpha == approx(slab_l.alpha)
+        assert ouc_l.beta == approx(slab_l.beta)
+        assert ouc_l.gamma == approx(slab_l.gamma)
+
     def test_normal_search(self):
         fcc = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Fe"], [[0, 0, 0]])
         for miller in [(1, 0, 0), (1, 1, 0), (1, 1, 1), (2, 1, 1)]:
@@ -630,8 +656,8 @@ class TestSlabGenerator(MatSciTest):
         # expect 2 and 6 bonds broken so we check for this.
         # Number of broken bonds are floats due to primitive
         # flag check and subsequent transformation of slabs.
-        assert slabs[0].energy == approx(8.0)
-        assert slabs[1].energy == approx(24.0)
+        assert slabs[0].energy == approx(2.0)
+        assert slabs[1].energy == approx(6.0)
 
 
 class TestReconstructionGenerator(MatSciTest):


### PR DESCRIPTION
## Summary
Copy of https://github.com/materialsproject/pymatgen/pull/4598

- Only take primitive slab cell if corresponding oriented unit cell is found.
- Add `reduce=True` keyword argument to `Structure.get_primitive_cell`. If `false`, `Structure.get_reduced_structure()` is not applied during recursive search for primitive cell.
- When searching for primitive cell of a slab and its corresponding orientated unit cell (OUC), use `reduce=False`.
    - For MgO(111) example in #4597 this allows the oriented unit cell to find primitive cell candidates which meet the constraints, otherwise it can't. 
    - Someone who's more knowledgable about Niggli reduction might be able to rationalise this.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Closes #4597