### PR TITLE
Lazy import matplotlib.pyplot in structure_analyzer

### DIFF
--- a/src/pymatgen/core/structure_analyzer.py
+++ b/src/pymatgen/core/structure_analyzer.py
@@ -8,7 +8,6 @@ import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-import matplotlib.pyplot as plt
 import numpy as np
 from scipy.spatial import Voronoi
 
@@ -18,6 +17,8 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from .local_env import JmolNN, VoronoiNN
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
     from pymatgen.core import Structure
 
 __author__ = "Shyue Ping Ong, Geoffroy Hautier, Sai Jayaraman"
@@ -144,7 +145,7 @@ class VoronoiAnalyzer:
         return sorted(voro_dict.items(), key=lambda x: (x[1], x[0]), reverse=True)[:most_frequent_polyhedra]
 
     @staticmethod
-    def plot_vor_analysis(voronoi_ensemble: list[tuple[str, float]]) -> plt.Axes:
+    def plot_vor_analysis(voronoi_ensemble: list[tuple[str, float]]) -> Axes:
         """Plot the Voronoi analysis.
 
         Args:
@@ -152,8 +153,10 @@ class VoronoiAnalyzer:
                 values for Voronoi analysis.
 
         Returns:
-            plt.Axes: Matplotlib Axes object with the plotted Voronoi analysis.
+            Axes: Matplotlib Axes object with the plotted Voronoi analysis.
         """
+        import matplotlib.pyplot as plt  # Lazy import: only used in this method
+
         labels, val = zip(*voronoi_ensemble, strict=True)
         arr = np.array(val, dtype=float)
         arr /= np.sum(arr)


### PR DESCRIPTION
## Summary

Move the `matplotlib.pyplot` import from module scope into `VoronoiAnalyzer.plot_vor_analysis()`. structure_analyzer.py is mainly used for analysis, while matplotlib is only needed for one plotting method. Deferring the import reduces import overhead for users who do not use plotting. This would be consistent with https://github.com/materialsproject/pymatgen/pull/4128, which applied a similar lazy-import refactor elsewhere in pymatgen.

`matplotlib.pyplot` accounts for roughly 16-18% of the current import time of `pymatgen.core.structure_analyzer` in local profiling, though exact numbers vary by machine and system load.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
