### PR TITLE
Bugfix for deserialization of legacy phase diagram data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ^(docs|tests/files|tasks.py)
+exclude: ^(docs|tests/files|test-files|tasks.py)
 
 ci:
   autoupdate_schedule: monthly

--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -440,7 +440,9 @@ class PhaseDiagram(MSONable):
         """
         try:
             computed_data = dct.get("computed_data")
-            elements = [Element(elem) for elem in dct["elements"]]
+            elements = [
+                Element.from_dict(elem) if isinstance(elem, dict) else Element(elem) for elem in dct["elements"]
+            ]
 
             # for backwards compatibility, check for old format
             if "all_entries" in dct:
@@ -484,8 +486,13 @@ class PhaseDiagram(MSONable):
         if isinstance(computed_data.get("qhull_data"), dict):
             computed_data["qhull_data"] = decoder.process_decoded(computed_data["qhull_data"])
 
-        # Convert qhull_entries from indices to actual entries
-        computed_data["qhull_entries"] = [entries[i] for i in computed_data["qhull_entries"]]
+        if all(isinstance(entry, dict) for entry in computed_data["qhull_entries"]):
+            computed_data["qhull_entries"] = [
+                decoder.process_decoded(entry) for entry in computed_data["qhull_entries"]
+            ]
+        else:
+            # Convert qhull_entries from indices to actual entries
+            computed_data["qhull_entries"] = [entries[i] for i in computed_data["qhull_entries"]]
 
         # Legacy el_refs stored as list of [Element_dict, Entry_dict] pairs
         el_refs_raw = computed_data.get("el_refs", [])

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -900,7 +900,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
         zero_weighted_kpoints = None
         if kconfig.get("zero_weighted_line_density"):
             # zero_weighted k-points along line mode path
-            kpath = HighSymmKpath(self.structure)
+            kpath = HighSymmKpath(self.structure, **kconfig.get("kpath_kwargs", {}))
             frac_k_points, k_points_labels = kpath.get_kpoints(
                 line_density=kconfig["zero_weighted_line_density"],
                 coords_are_cartesian=False,


### PR DESCRIPTION
- Patching both the primary `from_dict` and the deprecated `_from_dict_legacy` method of `PhaseDiagram` to work with legacy data
- Adds missing `kpath_kwargs` in VASP sets