### PR TITLE
Lazy-load POTCAR summary stats to reduce import overhead

### DIFF
--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -6,6 +6,7 @@ All major VASP input files.
 from __future__ import annotations
 
 import codecs
+import functools
 import hashlib
 import itertools
 import math
@@ -1919,6 +1920,12 @@ VASP_POTCAR_HASHES: dict = loadfn(f"{MODULE_DIR}/vasp_potcar_file_hashes.json")
 POTCAR_STATS_PATH: str = os.path.join(MODULE_DIR, "potcar-summary-stats.json.bz2")
 
 
+@functools.cache
+def _load_potcar_summary_stats() -> dict:
+    """Lazily load and cache POTCAR summary stats to avoid import-time overhead."""
+    return loadfn(POTCAR_STATS_PATH)
+
+
 class PmgVaspPspDirError(ValueError):
     """Error thrown when PMG_VASP_PSP_DIR is not configured, but POTCAR is requested."""
 
@@ -1989,9 +1996,6 @@ class PotcarSingle:
         "SHA256": str.strip,
         "COPYR": str.strip,
     }
-
-    # Used for POTCAR validation
-    _potcar_summary_stats = loadfn(POTCAR_STATS_PATH)
 
     def __init__(self, data: str, symbol: str | None = None) -> None:
         """
@@ -2344,9 +2348,9 @@ class PotcarSingle:
         # Thus we have to look for matches in all POTCAR dirs, not just the ones with
         # consistent values of LEXCH
         for func in self.functional_dir:
-            for titel_no_spc in self._potcar_summary_stats[func]:
+            for titel_no_spc in _load_potcar_summary_stats()[func]:
                 if self.TITEL.replace(" ", "") == titel_no_spc:
-                    for potcar_subvariant in self._potcar_summary_stats[func][titel_no_spc]:
+                    for potcar_subvariant in _load_potcar_summary_stats()[func][titel_no_spc]:
                         if self.VRHFIN.replace(" ", "") == potcar_subvariant["VRHFIN"]:
                             possible_match = {
                                 "POTCAR_FUNCTIONAL": func,
@@ -2636,7 +2640,7 @@ class PotcarSingle:
 
         identity: dict[str, list] = {"potcar_functionals": [], "potcar_symbols": []}
         for func in self.functional_dir:
-            for ref_psp in self._potcar_summary_stats[func].get(self.TITEL.replace(" ", ""), []):
+            for ref_psp in _load_potcar_summary_stats()[func].get(self.TITEL.replace(" ", ""), []):
                 if self.VRHFIN.replace(" ", "") != ref_psp["VRHFIN"]:
                     continue
 
@@ -3026,7 +3030,7 @@ class Potcar(list, MSONable):
             Potcar, a POTCAR using a single functional that matches the input spec.
         """
 
-        functionals = functionals or list(PotcarSingle._potcar_summary_stats)
+        functionals = functionals or list(_load_potcar_summary_stats())
         for functional in functionals:
             potcar = Potcar()
             matched = [False for _ in range(len(potcar_spec))]
@@ -3035,7 +3039,7 @@ class Potcar(list, MSONable):
                 titel_no_spc = titel.replace(" ", "")
                 symbol = titel.split(" ")[1].strip()
 
-                for stats in PotcarSingle._potcar_summary_stats[functional].get(titel_no_spc, []):
+                for stats in _load_potcar_summary_stats()[functional].get(titel_no_spc, []):
                     if PotcarSingle.compare_potcar_stats(spec["summary_stats"], stats):
                         potcar.append(PotcarSingle.from_symbol_and_functional(symbol=symbol, functional=functional))
                         matched[ispec] = True

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -53,7 +53,7 @@ _SUMM_STATS = _gen_potcar_summary_stats(append=False, vasp_psp_dir=str(FAKE_POTC
 def _mock_complete_potcar_summary_stats(monkeypatch: pytest.MonkeyPatch) -> None:
     # Override POTCAR library to use fake scrambled POTCARs
     monkeypatch.setitem(SETTINGS, "PMG_VASP_PSP_DIR", str(FAKE_POTCAR_DIR))
-    monkeypatch.setattr(PotcarSingle, "_potcar_summary_stats", _SUMM_STATS)
+    monkeypatch.setattr("pymatgen.io.vasp.inputs._load_potcar_summary_stats", lambda: _SUMM_STATS)
 
     # The fake POTCAR library is pretty big even with just a few sub-libraries
     # just copying over entries to work with PotcarSingle.is_valid


### PR DESCRIPTION
  ## Summary

  - Replace eager `PotcarSingle._potcar_summary_stats = loadfn(POTCAR_STATS_PATH)` class attribute with a module-level `@functools.cache` function (`_load_potcar_summary_stats()`) that defers loading until first use
  - `potcar-summary-stats.json.bz2` (~181 ms, 25.3 MB) is the single most expensive module-level load in `pymatgen.io.vasp.inputs`, but is only used in POTCAR validation methods -- it no longer penalizes every downstream import (e.g. `pymatgen.io.vasp.sets`, `MaterialsProject2020Compatibility`)

One note: `functools.cache` keeps the cache coherent across threads, but it does not guarantee single execution during concurrent first access, so `loadfn(POTCAR_STATS_PATH)` may still run multiple times transiently.

  ## Benchmark results

  Measured on `pymatgen.io.vasp.inputs` import:

  | Metric | Before | After | Improvement |
  |---|---|---|---|
  | Import time (median) | 660 ms | 460 ms | **-200 ms (30%)** |
  | Memory | 92.1 MB | 66.9 MB | **-25.2 MB (27%)** |

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
