### PR TITLE
updated RPA calculation parsing when ALGO=CHI

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -670,7 +670,11 @@ class Vasprun(MSONable):
             real_partyz, real_partxz]], [[imag_partxx, imag_partyy, imag_partzz,
             imag_partxy, imag_partyz, imag_partxz]]).
         """
-        return self.dielectric_data["density"]
+        keys=self.dielectric_data.keys()
+        if "density" not in keys:
+            return self.dielectric_data['INVERSE MACROSCOPIC DIELECTRIC TENSOR (including local field effects in RPA (Hartree))']
+        else:
+            return self.dielectric_data["density"]
 
     @property
     def optical_absorption_coeff(self) -> list[float] | None:
@@ -711,7 +715,8 @@ class Vasprun(MSONable):
         )
         # In a response function run there is no ionic steps, there is no SCF step
         if final_elec_steps == 0:
-            raise ValueError("there is no ionic step in response function ALGO=CHI.")
+            final_elec_steps=[]
+            warnings.warn("there is no ionic step in response function ALGO=CHI.")
 
         if self.incar.get("LEPSILON"):
             idx = 1
@@ -1358,6 +1363,7 @@ class Vasprun(MSONable):
             "G0W0",
             "GW",
             "BSE",
+            "CHI",
             # VASP renamed the GW tags in v6.
             "QPGW",
             "QPGW0",


### PR DESCRIPTION
## Fix handling of `ALGO=CHI` response function calculations in `Vasprun`

### Summary

This PR fixes several issues related to parsing VASP output from response function calculations (`ALGO=CHI`).

### Changes

- **`converged_electronic`**: Replace `ValueError` with a `warnings.warn()` when no ionic steps are found in an `ALGO=CHI` run. Response function calculations legitimately produce no SCF steps, so raising an exception was incorrect — a warning is more appropriate and allows parsing to continue.

- **`update_charge_from_potcar`**: Add `"CHI"` to the list of response-function `ALGO` tags that are excluded from charge updates via POTCAR. This is consistent with how other GW/BSE tags are handled.

### Motivation

`ALGO=CHI` runs were crashing during Vasprun parsing due to the hard `ValueError`, making it impossible to extract results (e.g. the dielectric tensor) from these calculations.