### PR TITLE
Extending the plot_bands and plot_dos methods of BztPlotter for more control

### DIFF
--- a/src/pymatgen/electronic_structure/boltztrap2.py
+++ b/src/pymatgen/electronic_structure/boltztrap2.py
@@ -1179,23 +1179,42 @@ class BztPlotter:
 
         return fig if ax is None else ax
 
-    def plot_bands(self):
+    def plot_bands(
+        self,
+        kpaths=None,
+        kpoints_lbls_dict=None,
+        density=20,
+    ) -> BSPlotter:
         """Plot a band structure on symmetry line using BSPlotter()."""
         if self.bzt_interp is None:
             raise ValueError("BztInterpolator not present")
 
-        sbs = self.bzt_interp.get_band_structure()
+        sbs = self.bzt_interp.get_band_structure(
+            kpaths=kpaths, kpoints_lbls_dict=kpoints_lbls_dict, density=density)
 
-        return BSPlotter(sbs).get_plot()
+        return BSPlotter(sbs)
 
-    def plot_dos(self, T=None, npoints=10000):
-        """Plot the total Dos using DosPlotter()."""
+    def plot_dos(
+        self,
+        T: float | None = None,
+        npoints: int = 10000,
+        label: str = "Total",
+        **kwargs,
+    ) -> DosPlotter:
+        """Plot the total Dos using DosPlotter().
+
+        Args:
+            T: parameter used to smooth the Dos
+            npoints: number of energy points of the Dos
+            label: a unique label for the Dos
+            kwargs: arguments passed to DosPlotter()
+        """
         if self.bzt_interp is None:
             raise ValueError("BztInterpolator not present")
 
         tdos = self.bzt_interp.get_dos(T=T, npts_mu=npoints)
-        dosPlotter = DosPlotter()
-        dosPlotter.add_dos("Total", tdos)
+        dosPlotter = DosPlotter(**kwargs)
+        dosPlotter.add_dos(label=label, dos=tdos)
 
         return dosPlotter
 

--- a/src/pymatgen/electronic_structure/boltztrap2.py
+++ b/src/pymatgen/electronic_structure/boltztrap2.py
@@ -1189,8 +1189,7 @@ class BztPlotter:
         if self.bzt_interp is None:
             raise ValueError("BztInterpolator not present")
 
-        sbs = self.bzt_interp.get_band_structure(
-            kpaths=kpaths, kpoints_lbls_dict=kpoints_lbls_dict, density=density)
+        sbs = self.bzt_interp.get_band_structure(kpaths=kpaths, kpoints_lbls_dict=kpoints_lbls_dict, density=density)
 
         return BSPlotter(sbs)
 

--- a/tests/electronic_structure/test_boltztrap2.py
+++ b/tests/electronic_structure/test_boltztrap2.py
@@ -330,8 +330,8 @@ class TestBztPlotter:
         fig = self.bztPlotter.plot_props("S", "mu", "temp", temps=[300, 500])
         assert fig is not None
 
-        fig = self.bztPlotter.plot_bands()
+        fig = self.bztPlotter.plot_bands().get_plot()
         assert fig is not None
 
-        fig = self.bztPlotter.plot_dos()
+        fig = self.bztPlotter.plot_dos().get_plot()
         assert fig is not None


### PR DESCRIPTION
## Summary
Extended the `plot_bands` and `plot_dos` methods of `BztPlotter()` in `pymatgen.electronic_structure.boltztrap2` to give users more control over plotting and to make the two methods' return behavior consistent.

Changes:
`plot_bands`
- Added arguments matching those of `BztInterpolator.get_band_structure`, allowing the band structure to be configured directly from the plotting call.
- Now returns a `BSPlotter` instance instead of a plot object, mirroring `plot_dos`.

`plot_dos`
- Added a label argument to annotate the DOS in the plot with  "Total" as default.
- Added `**kwargs`, which are forwarded directly to `DosPlotter(**kwargs)` for full customization of the underlying plotter.

Why?
Previously, `plot_bands` and `plot_dos` had inconsistent return types and limited configurability. `plot_dos` already returned a `DosPlotter` instance, while `plot_bands` did not expose the underlying `BSPlotter`. The above changes:
- Put both methods on equal footing by returning their respective plotter classes, enabling further downstream customization by the user.
- Reduce boilerplate by letting users pass band-structure and DOS plotting options directly through the `BztPlotter` interface.