### PR TITLE
Change border_hyperplanes to use float values

### DIFF
--- a/src/pymatgen/analysis/chempot_diagram.py
+++ b/src/pymatgen/analysis/chempot_diagram.py
@@ -228,7 +228,7 @@ class ChemicalPotentialDiagram(MSONable):
 
     def _get_border_hyperplanes(self) -> np.ndarray:
         """Get an array of the bounding hyperplanes given by elemental limits."""
-        border_hyperplanes = np.array([[0] * (self.dim + 1)] * (2 * self.dim))
+        border_hyperplanes = np.array([[0.0] * (self.dim + 1)] * (2 * self.dim))
 
         for idx, limit in enumerate(self.lims):
             border_hyperplanes[2 * idx, idx] = -1


### PR DESCRIPTION
Very minor update to the `ChemicalPotentialDiagram` setup.
Essentially, the initialisation of the border hyperplanes arrays with `0` rather than `0.0` implicitly sets the array `dtyle` as `int`. If one then sets `default_min_limit` as a float rather than whole integer, this can then cause QHull errors due to (unintentional) enforced rounding in the chemical potential diagram construction.
MWE:
```python
from doped.chemical_potentials import ChemicalPotentialDiagram, get_entries_in_chemsys

cpd = ChemicalPotentialDiagram(get_entries_in_chemsys("Cs-Cd-Te"), default_min_limit=-8)
domains = cpd.domains  # works fine

cpd = ChemicalPotentialDiagram(get_entries_in_chemsys("Cs-Cd-Te"), default_min_limit=-7)
domains = cpd.domains  # works fine

cpd = ChemicalPotentialDiagram(get_entries_in_chemsys("Cs-Cd-Te"), default_min_limit=-7.5)
domains = cpd.domains  # crashes with QHull error, traceback below
```

To confirm, `default_min_limit` is intended to be a float, and not enforced as an integer:
https://github.com/materialsproject/pymatgen-core/blob/e4b7a2a20620de9326d440d2a4777c42fb1d2662/src/pymatgen/analysis/chempot_diagram.py#L78-L93

Traceback:
```
---------------------------------------------------------------------------
QhullError                                Traceback (most recent call last)
Cell In[38], line 4
      1 from doped.chemical_potentials import ChemicalPotentialDiagram, get_entries_in_chemsys
      3 cpd = ChemicalPotentialDiagram(get_entries_in_chemsys("Cs-Cd-Te"), default_min_limit=-7.5)
----> 4 domains = cpd.domains

File ~/miniconda3/lib/python3.13/site-packages/pymatgen/analysis/chempot_diagram.py:601, in ChemicalPotentialDiagram.domains(self)
    597 @property
    598 @lru_cache(maxsize=1)  # noqa: B019
    599 def domains(self) -> dict[str, np.ndarray]:
    600     """Mapping of formulas to array of domain boundary points."""
--> 601     return self._get_domains()

File ~/miniconda3/lib/python3.13/site-packages/pymatgen/analysis/chempot_diagram.py:216, in ChemicalPotentialDiagram._get_domains(self)
    214 hs_hyperplanes = np.vstack([hyperplanes, border_hyperplanes])
    215 interior_point = np.min(self.lims, axis=1) + 1e-1
--> 216 hs_int = HalfspaceIntersection(hs_hyperplanes, interior_point)
    218 domains: dict[str, list] = {entry.reduced_formula: [] for entry in entries}
    220 for intersection, facet in zip(hs_int.intersections, hs_int.dual_facets, strict=True):

File scipy/spatial/_qhull.pyx:2879, in scipy.spatial._qhull.HalfspaceIntersection.__init__()

File scipy/spatial/_qhull.pyx:356, in scipy.spatial._qhull._Qhull.__init__()

QhullError: QH6023 qhull input error: feasible point is not clearly inside halfspace
feasible point:   -7.4   -7.4   -7.4 
     halfspace:     -1      0      0 
     at offset:     -7  and distance: 0.4000000000000004 
The halfspace was at index 16

While executing:  | qhull H 
Options selected for Qhull 2020.2.r 2020/08/31:
  run-id 2045143093  Halfspace  _maxoutside  0
  ```