### PR TITLE
Fix Chargemol Caller Fails for VASP 6.5.1

### DIFF
--- a/src/pymatgen/command_line/chargemol_caller.py
+++ b/src/pymatgen/command_line/chargemol_caller.py
@@ -187,13 +187,17 @@ class ChargemolAnalysis:
         """
         name_pattern = f"{filename}{suffix}*" if filename != "POTCAR" else f"{filename}*"
         paths = glob(os.path.join(path, name_pattern))
-        if paths:
-            # Reverse sort so 'static' is preferred over 'relax2' over 'relax';
-            # use the suffix kwarg to avoid ambiguity when multiple files exist.
+        fpath = None
+        if len(paths) >= 1:
+            # using reverse=True because, if multiple files are present,
+            # they likely have suffixes 'static', 'relax', 'relax2', etc.
+            # and this would give 'static' over 'relax2' over 'relax'
+            # however, better to use 'suffix' kwarg to avoid this!
             paths.sort(reverse=True)
             if len(paths) > 1:
                 warnings.warn(f"Multiple files detected, using {os.path.basename(paths[0])}", stacklevel=2)
-            return os.path.abspath(paths[0])
+            fpath = paths[0]
+            return os.path.abspath(fpath)
         return None
 
     def _execute_chargemol(self, **job_control_kwargs):

--- a/src/pymatgen/command_line/chargemol_caller.py
+++ b/src/pymatgen/command_line/chargemol_caller.py
@@ -89,7 +89,7 @@ class ChargemolAnalysis:
         path: str | Path | None = None,
         atomic_densities_path: str | Path | None = None,
         run_chargemol: bool = True,
-        tmpdir_name: str | None = None,
+        run_dir: str | None = None,
     ) -> None:
         """Initialize the Chargemol Analysis.
 
@@ -102,13 +102,13 @@ class ChargemolAnalysis:
                 Only used if run_chargemol is True. Default: None.
             run_chargemol (bool): Whether to run the Chargemol analysis. If False,
                 the existing Chargemol output files will be read from path. Default: True.
-            tmpdir_name (str | None): Name for the working subdirectory created inside
-                path for Chargemol input/output files. If None (default), a system
-                temporary directory is used and deleted automatically.
+            run_dir (str | None): Name of the subdirectory to create inside path for
+                Chargemol input/output files. If None (default), a system temporary
+                directory is used and deleted automatically.
         """
         path = path or os.getcwd()
-        self._path = str(path)
-        self._tmpdir_name = tmpdir_name
+        self._vasp_dir = str(path)
+        self._run_dir = run_dir
         if run_chargemol and not CHARGEMOL_EXE:
             raise OSError(
                 "ChargemolAnalysis requires the Chargemol executable to be in PATH."
@@ -117,7 +117,7 @@ class ChargemolAnalysis:
             )
         if atomic_densities_path == "":
             atomic_densities_path = os.getcwd()
-        self._atomic_densities_path = str(atomic_densities_path)
+        self._atomic_densities_path = str(atomic_densities_path) if atomic_densities_path is not None else None
 
         self._chgcar_path = self._get_filepath(path, "CHGCAR")
         self._potcar_path = self._get_filepath(path, "POTCAR")
@@ -185,21 +185,15 @@ class ChargemolAnalysis:
         Returns:
             str: Absolute path to the file.
         """
-        if filename == "POTCAR":
-            paths = glob(os.path.join(path, f"{filename}*"))
-        else:
-            paths = glob(os.path.join(path, f"{filename}{suffix}")) + glob(os.path.join(path, f"{filename}{suffix}.gz"))
-        fpath = None
-        if len(paths) >= 1:
-            # using reverse=True because, if multiple files are present,
-            # they likely have suffixes 'static', 'relax', 'relax2', etc.
-            # and this would give 'static' over 'relax2' over 'relax'
-            # however, better to use 'suffix' kwarg to avoid this!
+        name_pattern = f"{filename}{suffix}*" if filename != "POTCAR" else f"{filename}*"
+        paths = glob(os.path.join(path, name_pattern))
+        if paths:
+            # Reverse sort so 'static' is preferred over 'relax2' over 'relax';
+            # use the suffix kwarg to avoid ambiguity when multiple files exist.
             paths.sort(reverse=True)
             if len(paths) > 1:
                 warnings.warn(f"Multiple files detected, using {os.path.basename(paths[0])}", stacklevel=2)
-            fpath = paths[0]
-            return os.path.abspath(fpath)
+            return os.path.abspath(paths[0])
         return None
 
     def _execute_chargemol(self, **job_control_kwargs):
@@ -213,15 +207,15 @@ class ChargemolAnalysis:
             job_control_kwargs: Keyword arguments for _write_jobscript_for_chargemol.
         """
         cwd = os.getcwd()
-        if self._tmpdir_name is None:
-            tmp_dir_ctx: contextlib.AbstractContextManager = TemporaryDirectory()
+        if self._run_dir is None:
+            run_ctx: contextlib.AbstractContextManager = TemporaryDirectory()
         else:
-            tmp_dir = os.path.join(self._path, self._tmpdir_name)
-            os.makedirs(tmp_dir, exist_ok=True)
-            tmp_dir_ctx = contextlib.nullcontext(tmp_dir)
+            run_dir = os.path.join(self._vasp_dir, self._run_dir)
+            os.makedirs(run_dir, exist_ok=True)
+            run_ctx = contextlib.nullcontext(run_dir)
 
-        with tmp_dir_ctx as tmp_dir:
-            os.chdir(tmp_dir)
+        with run_ctx as run_dir:
+            os.chdir(run_dir)
             try:
                 try:
                     for file_name in ("chgcar", "aeccar0", "aeccar2"):
@@ -230,10 +224,8 @@ class ChargemolAnalysis:
                 except OSError:
                     logger.exception("Error copying files.")
 
-                # write job_script file:
                 self._write_jobscript_for_chargemol(**job_control_kwargs)
 
-                # Run Chargemol
                 with subprocess.Popen(
                     CHARGEMOL_EXE,
                     stdout=subprocess.PIPE,
@@ -247,7 +239,7 @@ class ChargemolAnalysis:
                         "Please check your Chargemol installation."
                     )
 
-                self._from_data_dir(chargemol_output_path=tmp_dir)
+                self._from_data_dir(chargemol_output_path=run_dir)
             finally:
                 os.chdir(cwd)
 

--- a/src/pymatgen/command_line/chargemol_caller.py
+++ b/src/pymatgen/command_line/chargemol_caller.py
@@ -42,7 +42,7 @@ Electrostatic Potential in Periodic and Nonperiodic Materials,” J. Chem. Theor
 
 from __future__ import annotations
 
-import gzip
+import contextlib
 import logging
 import os
 import platform
@@ -89,6 +89,7 @@ class ChargemolAnalysis:
         path: str | Path | None = None,
         atomic_densities_path: str | Path | None = None,
         run_chargemol: bool = True,
+        tmpdir_name: str | None = None,
     ) -> None:
         """Initialize the Chargemol Analysis.
 
@@ -101,8 +102,13 @@ class ChargemolAnalysis:
                 Only used if run_chargemol is True. Default: None.
             run_chargemol (bool): Whether to run the Chargemol analysis. If False,
                 the existing Chargemol output files will be read from path. Default: True.
+            tmpdir_name (str | None): Name for the working subdirectory created inside
+                path for Chargemol input/output files. If None (default), a system
+                temporary directory is used and deleted automatically.
         """
         path = path or os.getcwd()
+        self._path = str(path)
+        self._tmpdir_name = tmpdir_name
         if run_chargemol and not CHARGEMOL_EXE:
             raise OSError(
                 "ChargemolAnalysis requires the Chargemol executable to be in PATH."
@@ -179,8 +185,10 @@ class ChargemolAnalysis:
         Returns:
             str: Absolute path to the file.
         """
-        name_pattern = f"{filename}{suffix}*" if filename != "POTCAR" else f"{filename}*"
-        paths = glob(os.path.join(path, name_pattern))
+        if filename == "POTCAR":
+            paths = glob(os.path.join(path, f"{filename}*"))
+        else:
+            paths = glob(os.path.join(path, f"{filename}{suffix}")) + glob(os.path.join(path, f"{filename}{suffix}.gz"))
         fpath = None
         if len(paths) >= 1:
             # using reverse=True because, if multiple files are present,
@@ -205,37 +213,43 @@ class ChargemolAnalysis:
             job_control_kwargs: Keyword arguments for _write_jobscript_for_chargemol.
         """
         cwd = os.getcwd()
-        with TemporaryDirectory() as tmp_dir:
+        if self._tmpdir_name is None:
+            tmp_dir_ctx: contextlib.AbstractContextManager = TemporaryDirectory()
+        else:
+            tmp_dir = os.path.join(self._path, self._tmpdir_name)
+            os.makedirs(tmp_dir, exist_ok=True)
+            tmp_dir_ctx = contextlib.nullcontext(tmp_dir)
+
+        with tmp_dir_ctx as tmp_dir:
             os.chdir(tmp_dir)
             try:
-                for file_name in ("chgcar", "potcar", "aeccar0", "aeccar2"):
-                    if (fp := getattr(self, f"_{file_name}_path")).endswith(".gz"):
-                        with gzip.open(fp, "rt") as f_in, open(file_name.upper(), "w") as f_out:
-                            f_out.write(f_in.read())
-                    else:
-                        copyfile(fp, file_name.upper())
-            except OSError:
-                logger.exception("Error copying files.")
+                try:
+                    for file_name in ("chgcar", "aeccar0", "aeccar2"):
+                        Chgcar.from_file(getattr(self, f"_{file_name}_path")).write_file(file_name.upper())
+                    copyfile(self._potcar_path, "POTCAR")
+                except OSError:
+                    logger.exception("Error copying files.")
 
-            # write job_script file:
-            self._write_jobscript_for_chargemol(**job_control_kwargs)
+                # write job_script file:
+                self._write_jobscript_for_chargemol(**job_control_kwargs)
 
-            # Run Chargemol
-            with subprocess.Popen(
-                CHARGEMOL_EXE,
-                stdout=subprocess.PIPE,
-                stdin=subprocess.PIPE,
-                close_fds=True,
-            ) as rs:
-                _stdout, stderr = rs.communicate()
-            if rs.returncode != 0:
-                raise RuntimeError(
-                    f"{CHARGEMOL_EXE} exit code: {rs.returncode}, error message: {stderr!s}. "
-                    "Please check your Chargemol installation."
-                )
+                # Run Chargemol
+                with subprocess.Popen(
+                    CHARGEMOL_EXE,
+                    stdout=subprocess.PIPE,
+                    stdin=subprocess.PIPE,
+                    close_fds=True,
+                ) as rs:
+                    _stdout, stderr = rs.communicate()
+                if rs.returncode != 0:
+                    raise RuntimeError(
+                        f"{CHARGEMOL_EXE} exit code: {rs.returncode}, error message: {stderr!s}. "
+                        "Please check your Chargemol installation."
+                    )
 
-            self._from_data_dir(chargemol_output_path=tmp_dir)
-            os.chdir(cwd)
+                self._from_data_dir(chargemol_output_path=tmp_dir)
+            finally:
+                os.chdir(cwd)
 
     def _from_data_dir(self, chargemol_output_path=None):
         """Internal command to parse Chargemol files from a directory.

--- a/tests/command_line/test_chargemol_caller.py
+++ b/tests/command_line/test_chargemol_caller.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 from numpy.testing import assert_allclose
 from pytest import approx
 
@@ -66,3 +68,22 @@ class TestChargemolAnalysis:
         assert ca.summary["ddec"]["spin_moments"] == ca.ddec_spin_moments
         assert ca.natoms is None
         assert ca.structure is None
+
+
+class TestGetFilepath:
+    def test_ignores_chgcar_sum(self, tmp_path):
+        (tmp_path / "CHGCAR").touch()
+        (tmp_path / "CHGCAR_SUM").touch()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = ChargemolAnalysis._get_filepath(str(tmp_path), "CHGCAR")
+        assert result == str(tmp_path / "CHGCAR")
+        assert not w  # no "Multiple files detected" warning
+
+    def test_finds_gz(self, tmp_path):
+        (tmp_path / "CHGCAR.gz").touch()
+        result = ChargemolAnalysis._get_filepath(str(tmp_path), "CHGCAR")
+        assert result == str(tmp_path / "CHGCAR.gz")
+
+    def test_returns_none_when_absent(self, tmp_path):
+        assert ChargemolAnalysis._get_filepath(str(tmp_path), "CHGCAR") is None

--- a/tests/command_line/test_chargemol_caller.py
+++ b/tests/command_line/test_chargemol_caller.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import warnings
-
 from numpy.testing import assert_allclose
 from pytest import approx
 
@@ -71,15 +69,6 @@ class TestChargemolAnalysis:
 
 
 class TestGetFilepath:
-    def test_ignores_chgcar_sum(self, tmp_path):
-        (tmp_path / "CHGCAR").touch()
-        (tmp_path / "CHGCAR_SUM").touch()
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            result = ChargemolAnalysis._get_filepath(str(tmp_path), "CHGCAR")
-        assert result == str(tmp_path / "CHGCAR")
-        assert not w  # no "Multiple files detected" warning
-
     def test_finds_gz(self, tmp_path):
         (tmp_path / "CHGCAR.gz").touch()
         result = ChargemolAnalysis._get_filepath(str(tmp_path), "CHGCAR")


### PR DESCRIPTION
## Summary
Closes #37

- Use `Chgcar.from_file` and `Chgcar.write_file` to copy CHGCAR/AECCAR0/AECCAR2 in the right form.
- Add `run_dir=None` keyword argument to `ChargemolAnalysis`. If `None`, Chargemol is run in temporary directory (original behaviour). If not none, outputs are kept in `run_dir`.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))