### PR TITLE
chore: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -50,16 +50,16 @@ jobs:
           mv html/modules.html .
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@v1.0.13
         with:
           source: ./docs
           destination: ./_site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     environment:
@@ -70,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install uv with python version.
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.13"
           enable-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Python
         uses: actions/setup-python@v6
@@ -51,15 +51,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.0
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BUILD: cp${{ matrix.python-version }}-*
 
       - name: Save artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-${{ matrix.os }}-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
@@ -80,14 +80,14 @@ jobs:
           python-version: "3.14"
 
       - name: Get build artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: dist-*
           merge-multiple: true
           path: dist
 
       - name: Publish to PyPI or TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           skip-existing: true
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,12 +63,12 @@ jobs:
       OPT_BIN_DIR: ${{ github.workspace }}/opt/bin # for optional Ubuntu dependencies
     steps:
       - name: Check out repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Create mamba environment
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-name: pmg
           cache-environment: true
@@ -83,7 +83,7 @@ jobs:
             # openff-toolkit # TODO: doesn't support Python 3.13 yet
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install pymatgen and dependencies via uv
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Restore cache for optional Ubuntu/MacOS dependencies
         if: matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest'
         id: optbin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.OPT_BIN_DIR }}
           key: opt-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/_install_opt_unit_deps.sh') }}
@@ -115,6 +115,6 @@ jobs:
           pytest --cov=pymatgen --cov-report=xml tests --color=yes
       - name: Codecov
         if: github.ref == 'refs/heads/main' && matrix.config.os == 'ubuntu-latest' && matrix.config.python == '3.11'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump actions still on Node 20 to their latest Node 24-based releases
- Pin floating third-party tags to specific versions

### Bumps
- `actions/checkout` v5 → v6
- `actions/setup-python` v5 → v6 (jekyll workflow)
- `actions/cache` v4 → v5
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v5 → v8
- `actions/configure-pages` v5 → v6
- `actions/upload-pages-artifact` v4 → v5
- `actions/deploy-pages` v4 → v5
- `mamba-org/setup-micromamba` v2 → v3
- `astral-sh/setup-uv` v7 → v8.1.0
- `codecov/codecov-action` v5 → v6
- `pypa/cibuildwheel` v3.4.0 → v3.4.1
- `pypa/gh-action-pypi-publish` `release/v1` → v1.14.0
- `actions/jekyll-build-pages` v1 → v1.0.13

## Test plan
- [ ] Lint workflow passes
- [ ] Test workflow passes
- [ ] Jekyll deploy workflow passes (verified after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)