### PR TITLE
perf(cython): tier-1 cleanups in coord_cython.pyx

### DIFF
--- a/src/pymatgen/util/coord_cython.pyx
+++ b/src/pymatgen/util/coord_cython.pyx
@@ -15,7 +15,7 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from libc.math cimport fabs, round
+from libc.math cimport fabs, floor, round
 from libc.stdlib cimport free, malloc
 
 np.import_array()
@@ -31,35 +31,65 @@ images = images_t.reshape((27, 3))
 
 cdef np.float_t[:, ::1] images_view = images
 
+
+# ---------------------------------------------------------------------------
+# (N, 3) @ (3, 3) specialized matmul.
+# The lattice matrix in pymatgen is always 3x3, so dot_2d / dot_2d_mod are
+# called only in this shape. Hand-unrolling the inner two dims:
+#   - holds the lattice in 9 scalar locals (registers)
+#   - makes the i-loop unit-stride on both read and write
+#   - lets the compiler auto-vectorize the outer N-loop
+# This replaces the previous generic ijk loop, which had a non-unit-stride
+# inner loop for row-major C arrays.
+# ---------------------------------------------------------------------------
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void dot_2d(np.float_t[:, ::1] a, np.float_t[:, ::1] b, np.float_t[:, ::1] o) nogil:
-    cdef int i, j, k, I, J, K
-    I = a.shape[0]
-    J = b.shape[1]
-    K = a.shape[1]
+cdef void dot_2d_3x3(
+    np.float_t[:, ::1] a,
+    np.float_t[:, ::1] b,
+    np.float_t[:, ::1] o,
+) nogil:
+    cdef int i, I = a.shape[0]
+    cdef double a0, a1, a2
+    cdef double b00 = b[0, 0], b01 = b[0, 1], b02 = b[0, 2]
+    cdef double b10 = b[1, 0], b11 = b[1, 1], b12 = b[1, 2]
+    cdef double b20 = b[2, 0], b21 = b[2, 1], b22 = b[2, 2]
+    for i in range(I):
+        a0 = a[i, 0]
+        a1 = a[i, 1]
+        a2 = a[i, 2]
+        o[i, 0] = a0 * b00 + a1 * b10 + a2 * b20
+        o[i, 1] = a0 * b01 + a1 * b11 + a2 * b21
+        o[i, 2] = a0 * b02 + a1 * b12 + a2 * b22
 
-    for j in range(J):
-        for i in range(I):
-            o[i, j] = 0
-        for k in range(K):
-            for i in range(I):
-                o[i, j] += a[i, k] * b[k, j]
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void dot_2d_mod(np.float_t[:, ::1] a, np.float_t[:, ::1] b, np.float_t[:, ::1] o) nogil:
-    cdef int i, j, k, I, J, K
-    I = a.shape[0]
-    J = b.shape[1]
-    K = a.shape[1]
+cdef void dot_2d_mod_3x3(
+    np.float_t[:, ::1] a,
+    np.float_t[:, ::1] b,
+    np.float_t[:, ::1] o,
+) nogil:
+    """Same as dot_2d_3x3 but applies a mod-1 to each input frac coord first.
 
-    for j in range(J):
-        for i in range(I):
-            o[i, j] = 0
-        for k in range(K):
-            for i in range(I):
-                o[i, j] += a[i, k] % 1 * b[k, j]
+    Implemented as ``a - floor(a)`` (numpy ``np.mod(a, 1)`` semantics — always
+    in [0, 1) for any real input) rather than ``a % 1``: the latter compiles to
+    a slow Python-style helper on cdef double and has C-vs-Python sign
+    differences for negative inputs.
+    """
+    cdef int i, I = a.shape[0]
+    cdef double a0, a1, a2
+    cdef double b00 = b[0, 0], b01 = b[0, 1], b02 = b[0, 2]
+    cdef double b10 = b[1, 0], b11 = b[1, 1], b12 = b[1, 2]
+    cdef double b20 = b[2, 0], b21 = b[2, 1], b22 = b[2, 2]
+    for i in range(I):
+        a0 = a[i, 0] - floor(a[i, 0])
+        a1 = a[i, 1] - floor(a[i, 1])
+        a2 = a[i, 2] - floor(a[i, 2])
+        o[i, 0] = a0 * b00 + a1 * b10 + a2 * b20
+        o[i, 1] = a0 * b01 + a1 * b11 + a2 * b21
+        o[i, 2] = a0 * b02 + a1 * b12 + a2 * b22
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -93,7 +123,7 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
     cdef int n_pbc_im = int(3 ** n_pbc)
 
     cdef np.float_t[:, ::1] frac_im
-    cdef int i, j, k, l, I, J
+    cdef int i, j, k, l, I, J, bestk = 0
 
     if n_pbc == 3:
         fcoords1 = lattice.get_lll_frac_coords(fcoords1)
@@ -135,9 +165,9 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
         ftol = np.asarray(lll_frac_tol, dtype=np.float64, order="C")
 
 
-    dot_2d_mod(fc1, lat, cart_f1)
-    dot_2d_mod(fc2, lat, cart_f2)
-    dot_2d(frac_im, lat, cart_im)
+    dot_2d_mod_3x3(fc1, lat, cart_f1)
+    dot_2d_mod_3x3(fc2, lat, cart_f2)
+    dot_2d_3x3(frac_im, lat, cart_im)
 
     vectors = np.empty((I, J, 3))
     d2 = np.empty((I, J))
@@ -145,7 +175,10 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
     cdef np.float_t[:, ::1] ds = d2
     cdef np.float_t best, d, da, db, dc, fdist
     cdef bint within_frac = True
-    cdef np.float_t[:] pre_im = <np.float_t[:3]> malloc(3 * sizeof(np.float_t))
+    # 3-element scratch buffer for the per-(i,j) preimage. Heap-alloc just for
+    # 24 bytes is wasteful and the memoryview indirection prevents the compiler
+    # from holding these in registers; a stack array is faster and simpler.
+    cdef double pre_im[3]
 
     for i in range(I):
         for j in range(J):
@@ -159,9 +192,11 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
                             within_frac = False
                             break
                 if within_frac:
-                    for l in range(3):
-                        pre_im[l] = cart_f2[j, l] - cart_f1[i, l]
+                    pre_im[0] = cart_f2[j, 0] - cart_f1[i, 0]
+                    pre_im[1] = cart_f2[j, 1] - cart_f1[i, 1]
+                    pre_im[2] = cart_f2[j, 2] - cart_f1[i, 2]
                     best = 1e100
+                    bestk = 0
                     for k in range(n_pbc_im):
                         # compilers have a hard time unrolling this
                         da = pre_im[0] + cart_im[k, 0]
@@ -172,19 +207,20 @@ def pbc_shortest_vectors(lattice, fcoords1, fcoords2, mask=None, return_d2=False
                             best = d
                             bestk = k
                     ds[i, j] = best
-                    for l in range(3):
-                        vs[i, j, l] = pre_im[l] + cart_im[bestk, l]
+                    vs[i, j, 0] = pre_im[0] + cart_im[bestk, 0]
+                    vs[i, j, 1] = pre_im[1] + cart_im[bestk, 1]
+                    vs[i, j, 2] = pre_im[2] + cart_im[bestk, 2]
             if not within_frac:
                 ds[i, j] = 1e20
-                for l in range(3):
-                    vs[i, j, l] = 1e20
+                vs[i, j, 0] = 1e20
+                vs[i, j, 1] = 1e20
+                vs[i, j, 2] = 1e20
 
     if not (n_pbc == 3):
         free(&frac_im[0,0])
     free(&cart_f1[0,0])
     free(&cart_f2[0,0])
     free(&cart_im[0,0])
-    free(&pre_im[0])
 
     if return_d2:
         return vectors, d2

--- a/tests/performance/bench_core.py
+++ b/tests/performance/bench_core.py
@@ -14,8 +14,11 @@ import timeit
 import warnings
 from typing import TYPE_CHECKING
 
-from pymatgen.core import Composition, Element, Species
+import numpy as np
+
+from pymatgen.core import Composition, Element, Lattice, Species
 from pymatgen.core.periodic_table import get_el_sp
+from pymatgen.util.coord_cython import is_coord_subset_pbc, pbc_shortest_vectors
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -134,6 +137,45 @@ def main() -> None:
     print("\n[Species]")
     run("Species('Fe', 2)", lambda: Species("Fe", 2))
     run("Species.from_str('Fe2+')", lambda: Species.from_str("Fe2+"))
+
+    # --- coord_cython hot paths --------------------------------------------
+    print("\n[coord_cython] pbc_shortest_vectors / is_coord_subset_pbc")
+    rng = np.random.default_rng(0)
+    lattice = Lattice.cubic(10.0)
+
+    # Small-ish (typical StructureMatcher inner call): 32 x 32.
+    fc32a = rng.random((32, 3))
+    fc32b = rng.random((32, 3))
+    run("pbc_shortest_vectors 32x32", lambda: pbc_shortest_vectors(lattice, fc32a, fc32b))
+
+    # Medium: 128 x 128.
+    fc128a = rng.random((128, 3))
+    fc128b = rng.random((128, 3))
+    run("pbc_shortest_vectors 128x128", lambda: pbc_shortest_vectors(lattice, fc128a, fc128b))
+
+    # Large: 256 x 256 (dominated by the i*j*27 inner kernel).
+    fc256a = rng.random((256, 3))
+    fc256b = rng.random((256, 3))
+    run("pbc_shortest_vectors 256x256", lambda: pbc_shortest_vectors(lattice, fc256a, fc256b))
+
+    # With mask (typical sparsity ~50%): also exercises the mask early-out.
+    mask128 = (rng.random((128, 128)) > 0.5).astype(np.int64)
+    run("pbc_shortest_vectors 128x128 +mask50", lambda: pbc_shortest_vectors(lattice, fc128a, fc128b, mask=mask128))
+
+    # With return_d2 (used by StructureMatcher).
+    run(
+        "pbc_shortest_vectors 128x128 return_d2",
+        lambda: pbc_shortest_vectors(lattice, fc128a, fc128b, return_d2=True),
+    )
+
+    # is_coord_subset_pbc: subset (16) inside superset (128).
+    fc_sub = fc128a[:16]
+    atol = np.array([1e-3, 1e-3, 1e-3])
+    sub_mask = np.zeros((16, 128), dtype=np.int64)
+    run(
+        "is_coord_subset_pbc 16-in-128",
+        lambda: is_coord_subset_pbc(fc_sub, fc128a, atol, sub_mask, pbc=(True, True, True)),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Four small, low-risk fixes inside the ``pbc_shortest_vectors`` hot path in ``coord_cython.pyx``. Together they cut ``pbc_shortest_vectors`` runtime **~15–23 %** on typical StructureMatcher-shaped inputs without changing semantics or call signatures.

This is Tier 1 of a larger review I ran on the file — the cheap, mechanical wins. Tier 2 items (``prange`` parallelism, branchless 27-image reduction, OpenMP linkage) are deliberately left out of this PR.

## What changes

### 1. ``cdef int bestk = 0``
``bestk`` was undeclared, which Cython treats as a Python object. Every ``bestk = k`` in the innermost loop boxed an int and every ``cart_im[bestk, l]`` unboxed it. The cdef removes the ``PyLong`` round-trip from the ``I*J*27`` hot path.

### 2. Stack-allocate the per-(i, j) preimage buffer
``pre_im`` was a 3-element ``malloc`` + memoryview + ``free``. Replace with ``cdef double pre_im[3]`` — one fewer allocation per call and the compiler can keep the values in registers.

### 3. Specialized ``(N, 3) @ (3, 3)`` dot kernels (``dot_2d_3x3`` / ``dot_2d_mod_3x3``)
The lattice matrix in pymatgen is always 3×3, so ``dot_2d`` / ``dot_2d_mod`` were only ever called as ``(N, 3) @ (3, 3)``. The previous generic ``ijk`` loop has the wrong order for row-major output: the inner ``i``-loop strides over ``o[i, j]`` by ``J`` and over ``a[i, k]`` by ``K``, defeating SIMD. The new hand-unrolled kernel holds the lattice in 9 scalar locals (registers), writes ``o[i, :]`` with unit stride, and lets the compiler auto-vectorize the outer ``N``-loop.

Also: ``dot_2d_mod_3x3`` replaces ``a % 1`` with ``a - floor(a)``. Same Python-style mod-1 semantics (in [0, 1) for all real inputs — verified bit-exact against ``np.mod`` on negative inputs in a direct comparison) but lowers to a single ``floor`` call instead of Cython's slow generic ``%`` helper for ``cdef double``.

The original generic ``dot_2d`` / ``dot_2d_mod`` are removed since they had no other callers.

## Benchmark deltas

(``tests/performance/bench_core.py``, M1 Mac, mean over 5 runs)

| Bench | Before | After | Speedup |
|---|---:|---:|---:|
| ``pbc_shortest_vectors`` 32×32 | 19.31 µs | 16.92 µs | **1.14×** |
| ``pbc_shortest_vectors`` 128×128 | 226.03 µs | 193.91 µs | **1.17×** |
| ``pbc_shortest_vectors`` 256×256 | 877.74 µs | 755.23 µs | **1.16×** |
| ``pbc_shortest_vectors`` 128×128 +mask50% | 171.26 µs | 138.67 µs | **1.23×** |
| ``pbc_shortest_vectors`` 128×128 return_d2 | 226.00 µs | 193.69 µs | **1.17×** |
| ``is_coord_subset_pbc`` 16-in-128 | 412 ns | 391 ns | 1.05× (noise) |

``is_coord_subset_pbc`` and ``coord_list_mapping_pbc`` are unchanged in this PR — earlier experiments adding ``np.ascontiguousarray`` and ``[:, ::1]`` contiguity hints to them showed a regression on tiny inputs (the call-overhead dominated). Their inner-loop structure is similar enough that the same Tier 1 tricks would apply if profile data warrants it later.

## Correctness

- Spot-check vs. numpy reference (including negative ``fcoords`` to exercise the ``a - floor(a)`` mod-1 path) confirms bit-exact output to ``pbc_shortest_vectors``.
- ``tests/core`` + ``tests/util`` + ``tests/symmetry`` + ``tests/transformations`` + ``tests/analysis``: **1204 passed**, 48 skipped, 4 xfailed (pre-existing). No new failures.
- ``ruff check .`` and ``ruff format --check .``: clean.

## Note on rebuilding

This is the first change to a ``.pyx`` in a while. Maintainers (or anyone re-running the benchmark locally) should ensure Cython re-generates ``coord_cython.c`` rather than re-linking the stale one — ``rm src/pymatgen/util/coord_cython.c && uv pip install -e . --no-build-isolation --reinstall-package pymatgen-core`` is the safe path. (I hit this during development — silently no speedup until the .c was deleted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)