### PR TITLE
Add normal search tolerance to SlabGenerator

### DIFF
--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -918,6 +918,7 @@ class SlabGenerator:
         in_unit_planes: bool = False,
         primitive: bool = True,
         max_normal_search: int | None = None,
+        normal_search_tol: float | None = None,
         reorient_lattice: bool = True,
     ) -> None:
         """Calculate the slab scale factor and uses it to generate an
@@ -962,6 +963,13 @@ class SlabGenerator:
                 cell for simulation. Normality is not guaranteed, but the oriented
                 cell will have the c vector as normal as possible to the surface.
                 The max absolute Miller index is usually sufficient.
+            normal_search_tol (float | None): If set, only candidates from the
+                max_normal_search iteration whose normalized cross product magnitude
+                with the surface normal is <= this value are accepted. Equivalently,
+                sin(angle between c and surface normal) must be <= normal_search_tol.
+                Among valid candidates the one yielding the fewest atoms (smallest
+                oriented unit cell volume) is chosen. Requires max_normal_search to
+                be set.
             reorient_lattice (bool): reorient the lattice such that
                 the c direction is parallel to the third lattice vector
         """
@@ -1047,9 +1055,19 @@ class SlabGenerator:
                     # Stop searching if cosine equals 1 or -1
                     if math.isclose(abs(cosine), 1, abs_tol=1e-8):
                         break
-                # We want the indices with the maximum absolute cosine,
-                # but smallest possible length.
-                uvw, cosine, osdm = max(candidates, key=lambda x: (x[1], -x[2]))
+                if normal_search_tol is not None:
+                    valid = [c for c in candidates if math.sqrt(max(0.0, 1.0 - c[1] ** 2)) <= normal_search_tol]
+                    if not valid:
+                        raise ValueError(
+                            f"No lattice vector found with cross-product magnitude <= {normal_search_tol}. "
+                            "Try increasing max_normal_search or relaxing normal_search_tol."
+                        )
+                    # Among candidates meeting the threshold, prefer fewest atoms (smallest cell volume).
+                    uvw, cosine, osdm = min(valid, key=lambda x: abs(np.linalg.det([*slab_scale_factor, x[0]])))
+                else:
+                    # We want the indices with the maximum absolute cosine,
+                    # but smallest possible length.
+                    uvw, cosine, osdm = max(candidates, key=lambda x: (x[1], -x[2]))
                 slab_scale_factor.append(uvw)
 
             slab_scale_factor = np.array(slab_scale_factor)  # type: ignore[assignment]
@@ -1081,7 +1099,10 @@ class SlabGenerator:
         # Calculate the most reduced structure as OUC to minimize calculations
         self.oriented_unit_cell = Structure.from_sites(single, to_unit_cell=True)
 
+        if normal_search_tol is not None and max_normal_search is None:
+            raise ValueError("normal_search_tol requires max_normal_search to be set.")
         self.max_normal_search = max_normal_search
+        self.normal_search_tol = normal_search_tol
         self.parent = initial_structure
         self.lll_reduce = lll_reduce
         self.center_slab = center_slab
@@ -1607,6 +1628,7 @@ def generate_all_slabs(
     center_slab: bool = False,
     primitive: bool = True,
     max_normal_search: int | None = None,
+    normal_search_tol: float | None = None,
     symmetrize: bool = False,
     repair: bool = False,
     include_reconstructions: bool = False,
@@ -1657,6 +1679,10 @@ def generate_all_slabs(
             cell for simulation. Normality is not guaranteed, but the oriented
             cell will have the c vector as normal as possible to the surface.
             The max absolute Miller index is usually sufficient.
+        normal_search_tol (float | None): Passed to SlabGenerator. If set,
+            only c-vector candidates with sin(angle to surface normal) <=
+            this value are accepted, and the one yielding fewest atoms is
+            chosen. Requires max_normal_search to be set.
         symmetrize (bool): Whether to ensure the surfaces of the
             slabs are equivalent.
         repair (bool): Whether to repair terminations with broken bonds
@@ -1684,6 +1710,7 @@ def generate_all_slabs(
             center_slab=center_slab,
             primitive=primitive,
             max_normal_search=max_normal_search,
+            normal_search_tol=normal_search_tol,
             in_unit_planes=in_unit_planes,
         )
         slabs = gen.get_slabs(

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -973,6 +973,8 @@ class SlabGenerator:
             reorient_lattice (bool): reorient the lattice such that
                 the c direction is parallel to the third lattice vector
         """
+        if normal_search_tol is not None and max_normal_search is None:
+            raise ValueError("normal_search_tol requires max_normal_search to be set.")
 
         def reduce_vector(vector: tuple[int, ...]) -> tuple[int, ...]:
             """Helper function to reduce vectors."""
@@ -1042,7 +1044,7 @@ class SlabGenerator:
             else:
                 index_range = sorted(
                     range(-max_normal_search, max_normal_search + 1),
-                    key=abs,
+                    key=lambda x: -abs(x),
                 )
                 candidates = []
                 for uvw in itertools.product(index_range, index_range, index_range):
@@ -1052,9 +1054,8 @@ class SlabGenerator:
                     osdm = np.linalg.norm(vec)
                     cosine = abs(np.dot(vec, normal) / osdm)
                     candidates.append((uvw, cosine, osdm))
-                    # When no threshold is set, stop as soon as a perfect match is found.
-                    # With ascending index order the first cosine=1 is also the smallest such vector.
-                    # When normal_search_tol is set we must collect all candidates first.
+                    # Stop searching if cosine equals 1 or -1 (unless normal_search_tol is set, in
+                    # which case we want to search for the most orthogonal vector within the tolerance).
                     if normal_search_tol is None and math.isclose(abs(cosine), 1, abs_tol=1e-8):
                         break
                 if normal_search_tol is not None:
@@ -1065,7 +1066,7 @@ class SlabGenerator:
                             "Try increasing max_normal_search or relaxing normal_search_tol."
                         )
                     # Among candidates meeting the threshold, prefer fewest atoms (smallest cell volume).
-                    uvw, cosine, osdm = min(valid, key=lambda x: abs(np.linalg.det([*slab_scale_factor, x[0]])))
+                    uvw, _, _ = min(valid, key=lambda x: abs(np.linalg.det([*slab_scale_factor, x[0]])))
                 else:
                     # We want the indices with the maximum absolute cosine,
                     # but smallest possible length.
@@ -1101,8 +1102,6 @@ class SlabGenerator:
         # Calculate the most reduced structure as OUC to minimize calculations
         self.oriented_unit_cell = Structure.from_sites(single, to_unit_cell=True)
 
-        if normal_search_tol is not None and max_normal_search is None:
-            raise ValueError("normal_search_tol requires max_normal_search to be set.")
         self.max_normal_search = max_normal_search
         self.normal_search_tol = normal_search_tol
         self.parent = initial_structure

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -1042,7 +1042,7 @@ class SlabGenerator:
             else:
                 index_range = sorted(
                     range(-max_normal_search, max_normal_search + 1),
-                    key=lambda x: -abs(x),
+                    key=abs,
                 )
                 candidates = []
                 for uvw in itertools.product(index_range, index_range, index_range):
@@ -1052,8 +1052,10 @@ class SlabGenerator:
                     osdm = np.linalg.norm(vec)
                     cosine = abs(np.dot(vec, normal) / osdm)
                     candidates.append((uvw, cosine, osdm))
-                    # Stop searching if cosine equals 1 or -1
-                    if math.isclose(abs(cosine), 1, abs_tol=1e-8):
+                    # When no threshold is set, stop as soon as a perfect match is found.
+                    # With ascending index order the first cosine=1 is also the smallest such vector.
+                    # When normal_search_tol is set we must collect all candidates first.
+                    if normal_search_tol is None and math.isclose(abs(cosine), 1, abs_tol=1e-8):
                         break
                 if normal_search_tol is not None:
                     valid = [c for c in candidates if math.sqrt(max(0.0, 1.0 - c[1] ** 2)) <= normal_search_tol]

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -486,6 +486,29 @@ class TestSlabGenerator(MatSciTest):
         gen = SlabGenerator(sc, (1, 1, 1), 10, 10, max_normal_search=1)
         assert gen.oriented_unit_cell.lattice.angles[1] == approx(90)
 
+    def test_normal_search_tol(self):
+        fcc = Structure.from_spacegroup("Fm-3m", Lattice.cubic(3), ["Fe"], [[0, 0, 0]])
+
+        # Cubic (1,0,0): c is naturally perpendicular; tight tol should succeed.
+        gen = SlabGenerator(fcc, (1, 0, 0), 10, 10, max_normal_search=1, normal_search_tol=1e-6)
+        slab = gen.get_slab()
+        assert slab.lattice.alpha == approx(90)
+        assert slab.lattice.beta == approx(90)
+
+        # Permissive tol (sin <= 0.5, i.e. angle <= 30 deg) should also pass for (1,1,1).
+        gen = SlabGenerator(fcc, (1, 1, 1), 10, 10, max_normal_search=2, normal_search_tol=0.5)
+        slab = gen.get_slab()
+        assert slab.lattice.alpha == approx(90)
+        assert slab.lattice.beta == approx(90)
+
+        # normal_search_tol requires max_normal_search.
+        with pytest.raises(ValueError, match="normal_search_tol requires max_normal_search"):
+            SlabGenerator(fcc, (1, 0, 0), 10, 10, normal_search_tol=0.1)
+
+        # (2,1,1) normal has no exact match within max_normal_search=1; tol=0 should raise.
+        with pytest.raises(ValueError, match="No lattice vector found"):
+            SlabGenerator(fcc, (2, 1, 1), 10, 10, max_normal_search=1, normal_search_tol=0.0)
+
     def test_get_slabs(self):
         gen = SlabGenerator(self.get_structure("CsCl"), [0, 0, 1], 10, 10)
 


### PR DESCRIPTION
## Summary

Add `normal_search_tol` keyword argument to `SlabGenerator`. When set, the cell with fewest atoms which satisfies $`\sin(\theta)<`$tol (where $\theta$ is the angle between the surface normal and c) is chosen.

Why is this useful? Vasp dipole correction is only valid for cells where c is orthogonal to a and b.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))
