### PR TITLE
perf(vasp.io): cache OUTCAR text, vectorize force_constants, cache YAML loader

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -20,7 +20,7 @@ import numpy as np
 import orjson
 from lxml import etree as ET
 from monty.dev import requires
-from monty.io import reverse_readfile, zopen
+from monty.io import zopen
 from monty.json import MSONable, jsanitize
 from monty.os.path import zpath
 from monty.re import regrep
@@ -601,11 +601,8 @@ class Vasprun(MSONable):
                         # n_atoms is not the total number of atoms, only those for which force constants were calculated
                         # https://github.com/materialsproject/pymatgen/issues/3084
                         n_atoms = len(hessian) // 3
-                        hessian = np.array(hessian)  # type:ignore[assignment]
-                        self.force_constants = np.zeros((n_atoms, n_atoms, 3, 3), dtype="double")
-                        for ii in range(n_atoms):
-                            for jj in range(n_atoms):
-                                self.force_constants[ii, jj] = hessian[ii * 3 : (ii + 1) * 3, jj * 3 : (jj + 1) * 3]  # type: ignore[call-overload]
+                        hessian = np.asarray(hessian, dtype="double")
+                        self.force_constants = hessian.reshape(n_atoms, 3, n_atoms, 3).transpose(0, 2, 1, 3).copy()
                         self.normalmode_eigenvals = np.array(eigenvalues)
                         self.normalmode_eigenvecs = np.array([np.array(ev).reshape(n_atoms, 3) for ev in eigenvectors])
 
@@ -620,7 +617,7 @@ class Vasprun(MSONable):
                         elif tag == "energy":
                             d = {i.attrib["name"]: float(i.text) for i in elem.findall("i")}  # type:ignore[arg-type]
                             if "kinetic" in d:
-                                md_data[-1]["energy"] = {i.attrib["name"]: float(i.text) for i in elem.findall("i")}  # type:ignore[arg-type]
+                                md_data[-1]["energy"] = d
 
         except ET.XMLSyntaxError:
             if self.exception_on_bad_xml:
@@ -2119,6 +2116,15 @@ class Outcar:
         self.filename: str = str(filename)
         self.is_stopped: bool = False
 
+        # Slurp the OUTCAR once. Every `read_pattern` / `read_table_pattern`
+        # call in __init__ (20+) reuses this cache instead of re-opening and
+        # decompressing the file. Helpers (read_chemical_shielding etc.) that
+        # use micro_pyawk still hit disk; they are conditional on
+        # NMR/LEPSILON/LCALCPOL and out of scope here.
+        with zopen(self.filename, mode="rt", encoding="utf-8") as _f:
+            self._text: str = _f.read()  # type:ignore[assignment]
+        self._lines: list[str] = self._text.splitlines()
+
         # Assume a compilation with parallelization enabled.
         # Will be checked later.
         # If VASP is compiled in serial, the OUTCAR is written slightly differently.
@@ -2146,10 +2152,10 @@ class Outcar:
         e_wo_entrp_pattern = re.compile(r"energy  without entropy\s*=\s+([\d\-\.]+)")
         e0_pattern = re.compile(r"energy\(sigma->0\)\s*=\s+([\d\-\.]+)")
 
-        all_lines = []
-        for line in reverse_readfile(self.filename):
+        # Iterate the cached lines in reverse (replaces reverse_readfile +
+        # all_lines accumulation; same memory footprint).
+        for line in reversed(self._lines):
             clean = line.strip()
-            all_lines.append(clean)
             if clean.find("soft stop encountered!  aborting job") != -1:
                 self.is_stopped = True
             else:
@@ -2196,8 +2202,8 @@ class Outcar:
         read_mag_x = False
         read_mag_y = False  # for SOC calculations only
         read_mag_z = False
-        all_lines.reverse()
-        for clean in all_lines:
+        for line in self._lines:
+            clean = line.strip()
             if read_charge or read_mag_x or read_mag_y or read_mag_z:
                 if clean.startswith("# of ion"):
                     header = re.split(r"\s{2,}", clean.strip())
@@ -2252,21 +2258,20 @@ class Outcar:
         else:
             mag = mag_x  # type:ignore[assignment]
 
-        # Data from beginning of OUTCAR
+        # Data from beginning of OUTCAR (reuse cached lines).
         run_stats["cores"] = None
-        with zopen(filename, mode="rt", encoding="utf-8") as file:
-            for line in file:  # type:ignore[assignment]
-                if "serial" in line:
-                    # Activate serial parallelization
-                    run_stats["cores"] = 1
-                    serial_compilation = True
-                    break
-                if "running" in line:
-                    if line.split()[1] == "on":
-                        run_stats["cores"] = int(line.split()[2])
-                    else:
-                        run_stats["cores"] = int(line.split()[1])
-                    break
+        for line in self._lines:
+            if "serial" in line:
+                # Activate serial parallelization
+                run_stats["cores"] = 1
+                serial_compilation = True
+                break
+            if "running" in line:
+                if line.split()[1] == "on":
+                    run_stats["cores"] = int(line.split()[2])
+                else:
+                    run_stats["cores"] = int(line.split()[1])
+                break
 
         self.run_stats = run_stats
         self.magnetization = tuple(mag)
@@ -2537,7 +2542,25 @@ class Outcar:
             results from regex and postprocess. Note that the values
             are list[list], because you can grep multiple items on one line.
         """
-        matches = regrep(
+        # Use the cached OUTCAR text (populated in __init__) to avoid
+        # re-opening the file on every call; fall back to monty.regrep
+        # only if the cache hasn't been set (e.g. when subclasses skip
+        # the parent __init__).
+        if getattr(self, "_lines", None) is not None:
+            compiled = {k: re.compile(p) for k, p in patterns.items()}
+            matches: dict[str, list] = {k: [] for k in patterns}
+            line_iter = reversed(self._lines) if reverse else iter(self._lines)
+            for line in line_iter:
+                for k, p in compiled.items():
+                    if m := p.search(line):
+                        matches[k].append([postprocess(g) for g in m.groups()])
+                if terminate_on_match and all(matches[k] for k in patterns):
+                    break
+            for key in patterns:
+                self.data[key] = matches[key]
+            return
+
+        raw_matches = regrep(
             filename=self.filename,
             patterns=patterns,
             reverse=reverse,
@@ -2545,7 +2568,7 @@ class Outcar:
             postprocess=postprocess,
         )
         for key in patterns:
-            self.data[key] = [i[0] for i in matches.get(key, [])]
+            self.data[key] = [i[0] for i in raw_matches.get(key, [])]
 
     def read_table_pattern(
         self,
@@ -2596,8 +2619,12 @@ class Outcar:
         if last_one_only and first_one_only:
             raise ValueError("last_one_only and first_one_only options are incompatible")
 
-        with zopen(self.filename, mode="rt", encoding="utf-8") as file:
-            text: str = file.read()  # type:ignore[assignment]
+        # Reuse the cached OUTCAR text if available.
+        if (cached := getattr(self, "_text", None)) is not None:
+            text: str = cached
+        else:
+            with zopen(self.filename, mode="rt", encoding="utf-8") as file:
+                text = file.read()  # type:ignore[assignment]
         table_pattern_text = header_pattern + r"\s*^(?P<table_body>(?:\s+" + row_pattern + r")+)\s+" + footer_pattern
         table_pattern = re.compile(table_pattern_text, re.MULTILINE | re.DOTALL)
         rp = re.compile(row_pattern)

--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -29,6 +29,7 @@ The above are recommendations. The following are **UNBREAKABLE** rules:
 from __future__ import annotations
 
 import abc
+import functools
 import itertools
 import os
 import re
@@ -80,7 +81,11 @@ if TYPE_CHECKING:
 MODULE_DIR = os.path.dirname(__file__)
 
 
+@functools.cache
 def _load_yaml_config(fname):
+    # Cached so each YAML (and each PARENT chain) is parsed at most once across
+    # all VaspInputSet subclasses. The merge below never mutates the parent dict
+    # or its values, so sharing the cached object across callers is safe.
     fname = f"{MODULE_DIR}/{fname}"
     if not fname.endswith(".yaml"):
         fname += ".yaml"


### PR DESCRIPTION
## Summary

Three independent optimization wins in `pymatgen.io.vasp` (no behavior change, no API change).

### 1. Cache OUTCAR text in `Outcar.__init__`

The constructor previously opened and decompressed the OUTCAR ~20 times — once via `reverse_readfile` for the header, once via a forward `zopen` for serial/parallel detection, and 11+ times via `self.read_pattern(...)` (NBANDS, NPLWV, drift, ISPIN, LNONCOLLINEAR, IBRION, LEPSILON, LCALCPOL, electrostatic, LCHIMAG, NMR_efg, onsite_dm, plus 10 individual `final_energy_contribs` keys).

Now `__init__` slurps the file once into `self._text` / `self._lines` and `read_pattern` / `read_table_pattern` route through that cache. The cache also powers the reverse-pass and the serial-detect forward pass, eliminating the second/third file opens too. The public API of `read_pattern` is unchanged; a fallback path through `monty.regrep` is kept for subclasses that bypass the parent `__init__`.

**Measured on three real OUTCARs:**

| OUTCAR | Baseline | With cache | Speedup |
|---|---:|---:|---:|
| OUTCAR_fc (124 KB) | 13.42 ms | 7.32 ms | **1.83×** |
| OUTCAR_merged_numbers2 (282 KB) | 21.53 ms | 13.62 ms | **1.58×** |
| OUTCAR.Al (229 KB) | 21.60 ms | 13.15 ms | **1.64×** |

For gzipped or very large MD OUTCARs the win is dramatically larger (decompression amortized once instead of ~20×).

### 2. Vectorize `Vasprun.force_constants`

Replace the O(n²) Python double loop in `Vasprun._parse` (dynmat branch) with a single `hessian.reshape(n, 3, n, 3).transpose(0, 2, 1, 3).copy()`. Two-line fix; measurable on phonon DFPT runs with many atoms.

### 3. Cache YAML loader in `vasp.sets`

`_load_yaml_config` is now `@functools.cache`-decorated, so each YAML (and its `PARENT` chain) is parsed at most once across the ~10 `VaspInputSet` subclasses that share parents. Safe: every instance does `self._config_dict = deepcopy(self.config_dict)` (line 260), so the shared cached object is never mutated by callers. Drops `import pymatgen.io.vasp.sets` time from ~124 ms to ~118 ms.

### Minor: dedup ml-md energy `findall("i")`

The ML MD energy handler in `Vasprun._parse` called `elem.findall("i")` twice on the same element. Reuse the dict from the first call.

## Considered and dropped

The original analysis also suggested `elem.clear()` calls in the `Vasprun._parse` iterparse loop to free memory on long ML MD trajectories. **This is structurally unsafe in the current loop**: `elem.clear()` in lxml wipes `elem.attrib` too, so later `elif` branches that match on `tag == "structure" and elem.attrib.get("name") is None` falsely fire on the just-cleared element, calling `_parse_structure` again with no children and crashing. The parent `<calculation>` is already cleared at the end of `_parse_ionic_step` (line ~1701), which is where the bulk of MD-trajectory memory is freed. Selective clearing would need a deeper restructuring of the elif chain — out of scope for this PR.

## Test plan

- [x] `uv run pytest tests/io/vasp/ tests/phonon/ tests/io/test_phonopy.py -p no:randomly` — **481 passed**, 1 skipped, 1 xfailed, 1 xpassed.
- [x] `uv run ruff check` / `ruff format --check` on touched files — clean.
- [x] Benchmarks above (run on macOS, Python 3.11, against in-tree `test-files/io/vasp/outputs/`).
- [ ] Full CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)