### PR TITLE
perf(import): lazy Magmom + MagneticSpaceGroup imports

### DIFF
--- a/src/pymatgen/core/operations.py
+++ b/src/pymatgen/core/operations.py
@@ -12,9 +12,14 @@ from typing import TYPE_CHECKING, Literal, cast
 import numpy as np
 from monty.json import MSONable
 
-from pymatgen.electronic_structure.core import Magmom
+# pymatgen.electronic_structure.core.Magmom is imported lazily inside
+# SymmOp.operate_magmom. It's the only call site and the eager import
+# would pull electronic_structure.core into every `import pymatgen.core`.
 from pymatgen.util.due import Doi, due
 from pymatgen.util.string import transformation_to_string
+
+if TYPE_CHECKING:
+    from pymatgen.electronic_structure.core import Magmom
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -589,6 +594,8 @@ class MagSymmOp(SymmOp):
         Returns:
             Magnetic moment after operator applied as Magmom class
         """
+        from pymatgen.electronic_structure.core import Magmom
+
         # Type casting to handle lists as input
         magmom = Magmom(magmom)
 

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -43,8 +43,11 @@ from pymatgen.core.operations import SymmOp
 from pymatgen.core.periodic_table import _PT_UNIT, DummySpecies, Element, Species, get_el_sp
 from pymatgen.core.sites import PeriodicSite, Site
 from pymatgen.core.units import Length, Mass
-from pymatgen.electronic_structure.core import Magmom
-from pymatgen.symmetry.maggroups import MagneticSpaceGroup
+
+# Magmom and MagneticSpaceGroup are imported lazily inside
+# IStructure.from_magnetic_spacegroup; they're the only call site and the
+# eager imports drag in pymatgen.electronic_structure.core + symmetry.maggroups
+# + symmetry.groups (~6-10 ms) on every `from pymatgen.core import Structure`.
 from pymatgen.util.coord import all_distances, get_angle, lattice_points_in_supercell
 from pymatgen.util.due import Doi, due
 
@@ -62,6 +65,7 @@ if TYPE_CHECKING:
     from matgl.ext.ase import TrajectoryObserver
     from numpy.typing import ArrayLike, NDArray
 
+    from pymatgen.symmetry.maggroups import MagneticSpaceGroup
     from pymatgen.util.typing import CompositionLike, PathLike, SpeciesLike
 
 FileFormats: TypeAlias = Literal[
@@ -1449,6 +1453,9 @@ class IStructure(SiteCollection, MSONable):
         """
         if "magmom" not in site_properties:
             raise ValueError("Magnetic moments have to be defined.")
+
+        from pymatgen.electronic_structure.core import Magmom
+        from pymatgen.symmetry.maggroups import MagneticSpaceGroup
 
         magmoms = [Magmom(m) for m in site_properties["magmom"]]
 


### PR DESCRIPTION
## Summary

Move two module-level imports to local scope inside the single methods that use them. Both are constructed by rarely-called methods, but their eager imports drag in three submodules on every `from pymatgen.core import Structure`.

## Cold-import savings

| | Median |
|---|---:|
| Before this PR | 167 ms |
| After this PR  | **156 ms** |
| Saved | **−11 ms** (~6.5%) |

(Stacks on the recent Tier 1 lazy-scipy work that took us from 244 → 167 ms.)

## Changes

**`pymatgen/core/structure.py`**
- Drop top-level `from pymatgen.electronic_structure.core import Magmom`
- Drop top-level `from pymatgen.symmetry.maggroups import MagneticSpaceGroup`
- Add `MagneticSpaceGroup` to the `TYPE_CHECKING` block (it's used in `IStructure.from_magnetic_spacegroup`'s signature annotation)
- Local `from pymatgen.electronic_structure.core import Magmom` and `from pymatgen.symmetry.maggroups import MagneticSpaceGroup` inside `IStructure.from_magnetic_spacegroup` (the only call site)

**`pymatgen/core/operations.py`**
- Drop top-level `from pymatgen.electronic_structure.core import Magmom`
- Add `Magmom` to a new `TYPE_CHECKING` block (used in `MagSymmOp.operate_magmom`'s signature annotation)
- Local `from pymatgen.electronic_structure.core import Magmom` inside `MagSymmOp.operate_magmom` (the only call site)

Both files already have `from __future__ import annotations`, so type annotations are strings at runtime and need no real import.

## Modules no longer loaded by `from pymatgen.core import Structure`

```
pymatgen.electronic_structure.core
pymatgen.symmetry.maggroups
pymatgen.symmetry.groups
pymatgen.symmetry.settings
```

Verified via `sys.modules` introspection after a fresh interpreter import.

## Test plan

- [x] `uv run pytest tests/core/ -p no:randomly` — **800 passed**, 35 skipped, 4 xfailed
- [x] ruff check + format clean (pre-commit hooks pass)
- [x] mypy clean
- [x] Smoke-tested `MagSymmOp.operate_magmom` end-to-end (the lazily-imported `Magmom` resolves correctly inside the method body)
- [ ] Full CI matrix

## Notes

Follow-up to the import-latency audit (Tier 2 finding F1). Tier 3 — replacing `scipy.constants` in `pymatgen/core/units.py` with CODATA literals — would be the next significant win (~50 ms) and would also evict the `numpy.f2py → fileinput → charset_normalizer` chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)