### PR TITLE
Use ``math.lcm``/``math.gcd`` to avoid deprecation warnings and cleanup some redundant code

### DIFF
--- a/src/pymatgen/command_line/enumlib_caller.py
+++ b/src/pymatgen/command_line/enumlib_caller.py
@@ -37,7 +37,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import requires
-from monty.fractions import lcm
 from monty.tempfile import ScratchDir
 
 from pymatgen.core import DummySpecies, PeriodicSite, Structure
@@ -250,7 +249,7 @@ class EnumlibAdaptor:
         n_disordered = sum(len(s) for s in disordered_sites)
         base = int(
             n_disordered
-            * lcm(
+            * math.lcm(
                 *(
                     fraction.limit_denominator(n_disordered * self.max_cell_size).denominator
                     for fraction in map(fractions.Fraction, index_amounts)

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -17,7 +17,7 @@ from itertools import combinations_with_replacement, product
 from typing import TYPE_CHECKING
 
 from monty.dev import deprecated
-from monty.fractions import gcd, gcd_float
+from monty.fractions import gcd_float
 from monty.json import MSONable
 from monty.serialization import loadfn
 
@@ -671,7 +671,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         """
         reduced = self.element_composition
         if all(val == int(val) for val in self.values()):
-            reduced /= gcd(*(int(i) for i in self.values()))
+            reduced /= math.gcd(*(int(i) for i in self.values()))
 
         anon = ""
         for elem, amt in zip(string.ascii_uppercase, sorted(reduced.values()), strict=False):
@@ -1373,7 +1373,7 @@ def reduce_formula(
     # Enforce integer for calculating greatest common divisor
     factor: int = 1
     if all(int(i) == i for i in sym_amt.values()):
-        factor = abs(gcd(*(int(i) for i in sym_amt.values())))
+        factor = abs(math.gcd(*(int(i) for i in sym_amt.values())))
 
     # If the composition contains polyanion
     poly_anions: list[str] = []

--- a/src/pymatgen/core/interface.py
+++ b/src/pymatgen/core/interface.py
@@ -585,7 +585,7 @@ class GrainBoundaryGenerator:
 
                 _plane = np.matmul(_rotation_axis, metric)
                 fractions = [Fraction(x).limit_denominator() for x in _plane]
-                least_mul = reduce(lcm, [fraction.denominator for fraction in fractions])
+                least_mul = reduce(math.lcm, [fraction.denominator for fraction in fractions])
                 _plane = cast("tuple[int, int, int]", tuple(round(x * least_mul) for x in _plane))
 
         else:
@@ -1020,7 +1020,7 @@ class GrainBoundaryGenerator:
 
                 surface = np.matmul(r_axis, metric)
                 fractions = [Fraction(x).limit_denominator() for x in surface]
-                least_mul = reduce(lcm, [fraction.denominator for fraction in fractions])
+                least_mul = reduce(math.lcm, [fraction.denominator for fraction in fractions])
                 surface = cast(
                     "tuple[int, int, int] | tuple[int, int, int,int]",
                     tuple(round(x * least_mul) for x in surface),
@@ -1268,7 +1268,7 @@ class GrainBoundaryGenerator:
         if surface is None:
             raise ValueError("surface is None.")
         fractions = [Fraction(x).limit_denominator() for x in surface]
-        least_mul = reduce(lcm, [fraction.denominator for fraction in fractions])
+        least_mul = reduce(math.lcm, [fraction.denominator for fraction in fractions])
         surface = cast("tuple[int, int, int]", tuple(round(x * least_mul) for x in surface))
         if reduce(math.gcd, surface) != 1:
             index = reduce(math.gcd, surface)
@@ -1295,7 +1295,7 @@ class GrainBoundaryGenerator:
 
         # With the rotation matrix to construct the CSL lattice, check reference for details
         fractions = [Fraction(x).limit_denominator() for x in new_rot[:, kk]]
-        least_mul = reduce(lcm, [fraction.denominator for fraction in fractions])
+        least_mul = reduce(math.lcm, [fraction.denominator for fraction in fractions])
         scale = np.zeros((3, 3))
         scale[hh, hh] = 1
         scale[kk, kk] = least_mul

--- a/src/pymatgen/core/interface.py
+++ b/src/pymatgen/core/interface.py
@@ -13,7 +13,6 @@ from itertools import chain, combinations, product
 from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
-from monty.fractions import lcm
 from scipy.cluster.hierarchy import fcluster, linkage
 from scipy.spatial.distance import squareform
 
@@ -868,7 +867,7 @@ class GrainBoundaryGenerator:
                 index.pop(min_index)
                 frac1 = Fraction(lat[index[0]] ** 2 / lat[min_index] ** 2).limit_denominator(max_denominator)
                 frac2 = Fraction(lat[index[1]] ** 2 / lat[min_index] ** 2).limit_denominator(max_denominator)
-                com_lcm = lcm(frac1.denominator, frac2.denominator)
+                com_lcm = math.lcm(frac1.denominator, frac2.denominator)
                 ratio[min_index] = com_lcm
                 ratio[index[0]] = frac1.numerator * round(com_lcm / frac1.denominator)
                 ratio[index[1]] = frac2.numerator * round(com_lcm / frac2.denominator)
@@ -2138,7 +2137,7 @@ class GrainBoundaryGenerator:
                 index_len = len(miller_nonzero)
                 for i in range(index_len):
                     for j in range(i + 1, index_len):
-                        lcm_miller = lcm(miller[miller_nonzero[i]], miller[miller_nonzero[j]])
+                        lcm_miller = math.lcm(miller[miller_nonzero[i]], miller[miller_nonzero[j]])
                         scl_factor = [0, 0, 0]
                         scl_factor[miller_nonzero[i]] = -round(lcm_miller / miller[miller_nonzero[i]])
                         scl_factor[miller_nonzero[j]] = round(lcm_miller / miller[miller_nonzero[j]])
@@ -2379,7 +2378,7 @@ class GrainBoundaryGenerator:
                 miller[true_index] = frac[0].denominator
                 miller[index[0]] = frac[0].numerator
             else:
-                com_lcm = lcm(frac[0].denominator, frac[1].denominator)
+                com_lcm = math.lcm(frac[0].denominator, frac[1].denominator)
                 miller[true_index] = com_lcm
                 miller[index[0]] = frac[0].numerator * round(com_lcm / frac[0].denominator)
                 miller[index[1]] = frac[1].numerator * round(com_lcm / frac[1].denominator)

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -25,7 +25,6 @@ from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import orjson
-from monty.fractions import lcm
 from scipy.cluster.hierarchy import fcluster, linkage
 from scipy.spatial.distance import squareform
 
@@ -1020,7 +1019,7 @@ class SlabGenerator:
             c_index, _dist = max(non_orth_ind, key=lambda t: t[1])
 
             if len(non_orth_ind) > 1:
-                lcm_miller = lcm(*(miller_index[i] for i, _d in non_orth_ind))
+                lcm_miller = math.lcm(*(miller_index[i] for i, _d in non_orth_ind))
                 for (ii, _di), (jj, _dj) in itertools.combinations(non_orth_ind, 2):
                     scale_factor = [0, 0, 0]
                     scale_factor[ii] = -round(lcm_miller / miller_index[ii])
@@ -2142,13 +2141,8 @@ def hkl_transformation(
         transf (3x3 array): The matrix that transforms a lattice from A to B.
         miller_index (tuple[int, ...]): The Miller index [h, k, l] to transform.
     """
-
-    def math_lcm(a: int, b: int) -> int:
-        """Calculate the least common multiple."""
-        return a * b // math.gcd(a, b)
-
     # Convert the elements of the transformation matrix to integers
-    reduced_transf = reduce(math_lcm, [int(1 / i) for i in itertools.chain(*transf) if i != 0]) * transf
+    reduced_transf = reduce(math.lcm, [int(1 / i) for i in itertools.chain(*transf) if i != 0]) * transf
     reduced_transf = reduced_transf.astype(int)
 
     # Perform the transformation

--- a/src/pymatgen/transformations/advanced_transformations.py
+++ b/src/pymatgen/transformations/advanced_transformations.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 from joblib import Parallel, delayed
 from monty.dev import requires
-from monty.fractions import lcm
 from monty.json import MSONable
 
 from pymatgen.command_line.enumlib_caller import EnumError, EnumlibAdaptor
@@ -664,11 +663,6 @@ class MagOrderingTransformation(AbstractTransformation):
         """Determine the smallest supercell that is able to enumerate
         the provided structure with the given order parameter.
         """
-
-        def lcm(n1, n2):
-            """Find least common multiple of two numbers."""
-            return n1 * n2 / math.gcd(n1, n2)
-
         # assumes all order parameters for a given species are the same
         mag_species_order_parameter = {}
         mag_species_occurrences = {}
@@ -691,7 +685,7 @@ class MagOrderingTransformation(AbstractTransformation):
             denom = Fraction(order_parameter).limit_denominator(100).denominator
             num_atom_per_specie = mag_species_occurrences[sp]
             n_gcd = math.gcd(denom, num_atom_per_specie)
-            smallest_n.append(lcm(int(n_gcd), denom) / n_gcd)
+            smallest_n.append(math.lcm(int(n_gcd), denom) / n_gcd)
 
         return max(smallest_n)
 
@@ -1079,7 +1073,7 @@ class DopingTransformation(AbstractTransformation):
                 )
 
                 if sp_to_remove == sp:
-                    common_charge = lcm(int(abs(sp.oxi_state)), int(abs(ox)))  # type: ignore[arg-type]
+                    common_charge = math.lcm(int(abs(sp.oxi_state)), int(abs(ox)))  # type: ignore[arg-type]
                     n_dopant = common_charge / abs(ox)
                     nsp_to_remove = common_charge / abs(sp.oxi_state)  # type: ignore[arg-type]
                     logger.info(f"Doping {nsp_to_remove} {sp} with {n_dopant} {self.dopant}.")
@@ -1094,7 +1088,7 @@ class DopingTransformation(AbstractTransformation):
                 else:
                     ox_diff = int(abs(round(sp.oxi_state - ox)))
                     vac_ox = int(abs(sp_to_remove.oxi_state)) * ox_diff  # type: ignore[arg-type]
-                    common_charge = lcm(vac_ox, ox_diff)
+                    common_charge = math.lcm(vac_ox, ox_diff)
                     n_dopant = common_charge / ox_diff
                     nx_to_remove = common_charge / vac_ox
                     nx = supercell.composition[sp_to_remove]
@@ -1123,7 +1117,7 @@ class DopingTransformation(AbstractTransformation):
                 ox_diff = int(abs(round(sp.oxi_state - ox)))
                 anion_ox = int(abs(sp_to_remove.oxi_state))  # type: ignore[arg-type]
                 nx = supercell.composition[sp_to_remove]
-                common_charge = lcm(anion_ox, ox_diff)
+                common_charge = math.lcm(anion_ox, ox_diff)
                 n_dopant = common_charge / ox_diff
                 nx_to_remove = common_charge / anion_ox
                 logger.info(f"Doping {n_dopant} {sp} with {self.dopant} and removing {nx_to_remove} {sp_to_remove}.")


### PR DESCRIPTION
Updates usages of ``monty.fractions.gcd/lcm`` to avoid deprecation warnings with the latest ``monty``:
```
Category: FutureWarning
Message : gcd is deprecated, and will be removed on 2028-01-01
Use math.gcd instead.
Origin  : /opt/hostedtoolcache/Python/3.13.13/x64/lib/python3.13/site-packages/pymatgen/core/composition.py:1376
```

Also removes two cases of custom LCM functions which are redundant, to make code more compact.