### PR TITLE
Use trapezoidal integration for accurate DOS integration (thus carrier concentrations)

### DIFF
--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, NamedTuple, cast
 
 import numpy as np
 from monty.json import MSONable
+from scipy.integrate import trapezoid
 from scipy.ndimage import gaussian_filter1d
 from scipy.signal import hilbert
 from scipy.special import expit
@@ -443,58 +444,77 @@ class FermiDos(Dos, MSONable):
         self.energies = np.array(dos.energies)
         self.de = np.hstack((self.energies[1:], self.energies[-1])) - self.energies
 
-        # Normalize total density of states based on integral at 0 K
-        tdos = np.array(self.get_densities())
-        self.tdos = tdos * self.nelecs / (tdos * self.de)[self.energies <= self.efermi].sum()
-
         ecbm, evbm = self.get_cbm_vbm()
-        self.idx_vbm = int(np.argmin(abs(self.energies - evbm)))
-        self.idx_cbm = int(np.argmin(abs(self.energies - ecbm)))
-        self.idx_mid_gap = int(self.idx_vbm + (self.idx_cbm - self.idx_vbm) / 2)
+        self.idx_vbm = np.argmin(abs(self.energies - evbm))
+        self.idx_cbm = np.argmin(abs(self.energies - ecbm))
+        self.idx_mid_gap = round(self.idx_vbm + (self.idx_cbm - self.idx_vbm) / 2)
         self.A_to_cm = 1e-8
 
+        # Default integration bounds:
+        self.idx_h_integration = max(self.idx_mid_gap, self.idx_vbm + 1)
+        self.idx_e_integration = min(self.idx_mid_gap, self.idx_cbm - 1) + 1
+
+        # Normalize total density of states based on integral at 0 K; use trapezoid for accurate DOS
+        # integration, consistent with get_e_h_concs:
+        tdos = np.array(self.get_densities())
+        self.tdos = (
+            tdos * self.nelecs / trapezoid(tdos[: self.idx_h_integration], x=self.energies[: self.idx_h_integration])
+        )
+
         if bandgap:
-            eref = self.efermi if evbm < self.efermi < ecbm else (evbm + ecbm) / 2.0
+            self.energies[: self.idx_mid_gap] -= (bandgap - (ecbm - evbm)) / 2.0
+            self.energies[self.idx_mid_gap :] += (bandgap - (ecbm - evbm)) / 2.0
 
-            idx_fermi = int(np.argmin(abs(self.energies - eref)))
-
-            if idx_fermi == self.idx_vbm:
-                # Fermi level and VBM should have different indices
-                idx_fermi += 1
-
-            self.energies[:idx_fermi] -= (bandgap - (ecbm - evbm)) / 2.0
-            self.energies[idx_fermi:] += (bandgap - (ecbm - evbm)) / 2.0
-
-    def get_doping(self, fermi_level: float, temperature: float) -> float:
+    def get_e_h_concs(self, fermi_level: float, temperature: float) -> tuple[float, float]:
         """
-        Calculate the doping (majority carrier concentration) at a given
-        Fermi level and temperature. A simple Left Riemann sum is used for
-        integrating the density of states over energy & equilibrium Fermi-Dirac
-        distribution.
+        Get the electron and hole concentrations (in cm^-3) at a given Fermi
+        level and temperature.
 
         Args:
             fermi_level (float): The Fermi level in eV.
             temperature (float): The temperature in Kelvin.
 
         Returns:
-            float: The doping concentration in units of 1/cm^3. Negative values
-                indicate that the majority carriers are electrons (N-type),
-                whereas positive values indicates the majority carriers are holes
-                (P-type).
+            tuple[float, float]: The electron and hole concentrations in cm^-3.
         """
-        cb_integral = np.sum(
-            self.tdos[max(self.idx_mid_gap, self.idx_vbm + 1) :]
-            * f0(self.energies[max(self.idx_mid_gap, self.idx_vbm + 1) :], fermi_level, temperature)
-            * self.de[max(self.idx_mid_gap, self.idx_vbm + 1) :],
-            axis=0,
+        scale = self.volume * self.A_to_cm**3
+        ih, ie = self.idx_h_integration, self.idx_e_integration
+        e_conc: float = (
+            trapezoid(  # use trapezoid rule for accurate DOS integration
+                self.tdos[ie:] * f0(self.energies[ie:], fermi_level, temperature),
+                x=self.energies[ie:],
+            )
+            / scale
         )
-        vb_integral = np.sum(
-            self.tdos[: min(self.idx_mid_gap, self.idx_cbm - 1) + 1]
-            * f0(-self.energies[: min(self.idx_mid_gap, self.idx_cbm - 1) + 1], -fermi_level, temperature)
-            * self.de[: min(self.idx_mid_gap, self.idx_cbm - 1) + 1],
-            axis=0,
+        h_conc: float = (
+            trapezoid(
+                self.tdos[:ih] * f0(-self.energies[:ih], -fermi_level, temperature),
+                x=self.energies[:ih],
+            )
+            / scale
         )
-        return (vb_integral - cb_integral) / (self.volume * self.A_to_cm**3)
+
+        return e_conc, h_conc
+
+    def get_doping(self, fermi_level: float, temperature: float) -> float:
+        """
+        Calculate the doping (majority carrier concentration) at a given
+        Fermi level and temperature. Trapezoid sum is used for integrating the
+        density of states over energy & equilibrium Fermi-Dirac distribution.
+
+        Args:
+            fermi_level (float): The Fermi level in eV.
+            temperature (float): The temperature in Kelvin.
+
+        Returns:
+            float:
+                The doping concentration in units of 1/cm^3. Negative values
+                indicate that the majority carriers are electrons (N-type),
+                whereas positive values indicates the majority carriers are
+                holes (P-type).
+        """
+        e, h = self.get_e_h_concs(fermi_level, temperature)
+        return h - e
 
     def get_fermi(
         self,

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -447,7 +447,7 @@ class FermiDos(Dos, MSONable):
         ecbm, evbm = self.get_cbm_vbm()
         self.idx_vbm = np.argmin(abs(self.energies - evbm))
         self.idx_cbm = np.argmin(abs(self.energies - ecbm))
-        self.idx_mid_gap = round(self.idx_vbm + (self.idx_cbm - self.idx_vbm) / 2)
+        self.idx_mid_gap = (self.idx_vbm + self.idx_cbm) // 2
         self.A_to_cm = 1e-8
 
         # Default integration bounds:

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -103,6 +103,26 @@ class TestFermiDos:
         assert isinstance(dos_dict["densities"]["1"][0], float)
         assert not isinstance(dos_dict["densities"]["1"][0], np.float64)
 
+    def test_get_e_h_concs(self):
+        e_conc, h_conc = self.dos.get_e_h_concs(fermi_level=self.dos.efermi + 2.0, temperature=300)
+        assert e_conc == approx(2.6916894571633496e16)
+        assert h_conc == approx(4.906059878298583e-16)
+        assert self.dos.get_doping(fermi_level=self.dos.efermi + 2.0, temperature=300) == approx(h_conc - e_conc)
+
+        dos = Dos(
+            energies=np.array([0.0, 0.5, 1.0, 1.5, 2.0]),
+            densities={
+                Spin.up: np.array([1.0, 2.0e-4, 0.0, 3.0e-4, 4.0]),
+                Spin.down: np.array([0.5, 1.0e-4, 0.0, 1.5e-4, 2.0]),
+            },
+            efermi=0.8,
+        )
+        simple_dos = FermiDos(dos, structure=self.dos.structure)
+        e_conc, h_conc = simple_dos.get_e_h_concs(fermi_level=1.0, temperature=300)
+        assert e_conc == approx(2.4935783946261567e12)
+        assert h_conc == approx(8.311872785950934e11)
+        assert simple_dos.get_doping(fermi_level=1.0, temperature=300) == approx(h_conc - e_conc)
+
     def test_get_cbm_vbm_doping(self):
         dos = Dos(
             energies=np.array([0.0, 0.5, 1.0, 1.5, 2.0]),

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -68,7 +68,7 @@ class TestFermiDos:
         fermi0 = self.dos.efermi
         fermi_range = [fermi0 - 0.5, fermi0, fermi0 + 2.0, fermi0 + 2.2]
         dopings = [self.dos.get_doping(fermi_level=fermi_lvl, temperature=T) for fermi_lvl in fermi_range]
-        ref_dopings = [3.48077e21, 1.9235e18, -2.6909e16, -4.8723e19]
+        ref_dopings = [3.48144e21, 1.92284e18, -2.69169e16, -4.87399e19]
         for idx, c_ref in enumerate(ref_dopings):
             assert abs(dopings[idx] / c_ref - 1.0) <= 0.01
 
@@ -89,7 +89,7 @@ class TestFermiDos:
             else:
                 assert sci_dos.get_fermi(c_ref, temperature=T) - fermi_range[idx] == approx(-0.4651, abs=1e-2)
 
-        assert sci_dos.get_fermi_interextrapolated(-1e26, 300) == approx(7.50533, abs=1e-4)
+        assert sci_dos.get_fermi_interextrapolated(-1e26, 300) == approx(7.50545, abs=1e-4)
         assert sci_dos.get_fermi_interextrapolated(1e26, 300) == approx(-1.41276, abs=1e-4)
         assert sci_dos.get_fermi_interextrapolated(0.0, 300) == approx(2.9069, abs=1e-4)
 
@@ -117,9 +117,10 @@ class TestFermiDos:
             structure=self.dos.structure,
         )
         assert fermi_dos.get_cbm_vbm() == approx((1.1667, 0.75), abs=1e-4)
+        # <0 because e doping; greater DOS in CBM than VBM here, and efermi set to mid-gap:
         assert np.isclose(
             fermi_dos.get_doping(fermi_level=1.0, temperature=300),
-            -4.1557e11,  # <0 because e doping; greater DOS in CBM than VBM here, and efermi set to mid-gap
+            -1.6624e12,
             rtol=1e-3,
         )
 

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -103,7 +103,7 @@ class TestFermiDos:
         assert isinstance(dos_dict["densities"]["1"][0], float)
         assert not isinstance(dos_dict["densities"]["1"][0], np.float64)
 
-    def test_get_vbm_cbm_doping(self):
+    def test_get_cbm_vbm_doping(self):
         dos = Dos(
             energies=np.array([0.0, 0.5, 1.0, 1.5, 2.0]),
             densities={


### PR DESCRIPTION
This PR introduces some small changes to ``FermiDos`` carrier concentration calculations:
- Adds the `get_e_h_concs()` method, which returns the calculated electron and hole concentrations for a given Fermi level and temperature. This functionality was essentially already present in ``FermiDos.get_doping()``, except that it then returned ``h_conc - e_conc`` without allowing the user to access the individual values. This method can now be used for the individual values, while ``FermiDos.get_doping()`` now just uses the result of this method to give ``h_conc - e_conc`` as before.
- Uses trapezoidal integration instead of rectangular sum (left Riemann sum) integration for the density of states. This is marginally more accurate and with negligible additional compute cost for realistic systems (even with e.g. tens of thousands of repeated carrier concentration calculations as in self-consistent Fermi level determination, as tested locally).

This results in some minor updates to the test values, but <0.1% relative changes -- except for the toy model test in `test_get_cbm_vbm_doping()` due to the use of an extremely coarse DOS grid (only 5 data-points), where it gives a bigger difference (with the new result being more accurate).