### PR TITLE
Speed up StructureMatcher.group_structures with Improved Hashing

### DIFF
--- a/src/pymatgen/core/structure_matcher.py
+++ b/src/pymatgen/core/structure_matcher.py
@@ -86,12 +86,10 @@ class SiteOrderedIStructure(IStructure):
         each lookup requires fewer __eq__ calls.
         """
         sites_hash = hash(
-            tuple(
-                (site.species_string, *np.round(site.frac_coords*1000).tolist())
-                for site in self.sites
-            )
+            tuple((site.species_string, *np.round(site.frac_coords * 1000).tolist()) for site in self.sites)
         )
         return hash((super().__hash__(), sites_hash))
+
 
 class AbstractComparator(MSONable, abc.ABC):
     """

--- a/src/pymatgen/core/structure_matcher.py
+++ b/src/pymatgen/core/structure_matcher.py
@@ -77,9 +77,21 @@ class SiteOrderedIStructure(IStructure):
         return list(self.sites) == list(other.sites)
 
     def __hash__(self) -> int:
-        """Use the composition hash for now."""
-        return super().__hash__()
+        """Hash incorporating site positions to avoid LRU cache collisions.
 
+        The lru_cache on _get_reduced_istructure uses this hash as a key.
+        With a composition-only hash, structures sharing the same composition
+        all collide, requiring an O(N_sites) __eq__ call against each cached
+        entry to confirm a miss. Including rounded fractional coordinates means
+        each lookup requires fewer __eq__ calls.
+        """
+        sites_hash = hash(
+            tuple(
+                (site.species_string, *np.round(site.frac_coords*1000).tolist())
+                for site in self.sites
+            )
+        )
+        return hash((super().__hash__(), sites_hash))
 
 class AbstractComparator(MSONable, abc.ABC):
     """

--- a/src/pymatgen/core/structure_matcher.py
+++ b/src/pymatgen/core/structure_matcher.py
@@ -85,10 +85,9 @@ class SiteOrderedIStructure(IStructure):
         entry to confirm a miss. Including rounded fractional coordinates means
         each lookup requires fewer __eq__ calls.
         """
-        sites_hash = hash(
-            tuple((site.species_string, *np.round(site.frac_coords * 1000).tolist()) for site in self.sites)
-        )
-        return hash((super().__hash__(), sites_hash))
+        species = tuple(site.species_string for site in self.sites)
+        coords = np.round(self.frac_coords, 3).tobytes()
+        return hash((super().__hash__(), species, coords))
 
 
 class AbstractComparator(MSONable, abc.ABC):

--- a/tests/core/test_structure_matcher.py
+++ b/tests/core/test_structure_matcher.py
@@ -14,6 +14,7 @@ from pymatgen.core.structure_matcher import (
     FrameworkComparator,
     OccupancyComparator,
     OrderDisorderElementComparator,
+    SiteOrderedIStructure,
     StructureMatcher,
     get_linear_assignment_solution,
 )
@@ -1060,3 +1061,27 @@ class TestStructureMatcher(MatSciTest):
         assert sm.fit(s1, s2) is False
         assert sm.fit_anonymous(s1, s2) is False
         assert sm.get_mapping(s1, s2) is None
+
+
+def test_site_ordered_istructure_hash_uses_coords() -> None:
+    """Same composition but different fractional coordinates must hash differently.
+
+    Guards against regressions that revert SiteOrderedIStructure.__hash__ to
+    composition-only, which would collapse all same-composition structures into
+    one lru_cache bucket and restore the O(N²) lookup cost.
+    """
+    base = Structure.from_file(f"{TEST_DIR}/Na2Fe2PNO4Se4.json")
+    s1 = SiteOrderedIStructure.from_sites(base)
+
+    shifted = base.copy()
+
+    assert hash(s1) == hash(SiteOrderedIStructure.from_sites(shifted))
+
+    frac_coords = base.frac_coords
+    frac_coords[0] = (frac_coords[0] + 0.05) % 1.0  # shift one site well beyond 1e-3 rounding tolerance
+    for site, fc in zip(shifted, frac_coords, strict=True):
+        site.frac_coords = fc
+    s2 = SiteOrderedIStructure.from_sites(shifted)
+
+    assert s1.composition == s2.composition
+    assert hash(s1) != hash(s2)


### PR DESCRIPTION
## Summary

- Update the `SiteOrderedIStructure.__hash__` function to consider fractional coordinates as well as composition. This decreases the number of hash collisions when `StructureMatcher._get_reduced_istructure` (which is decorated with `@lru_cache`)) is called repeatedly with structures of the same composition.
- `StructureMatcher.group_structures` calls `StructureMatcher._get_reduced_istructure` repeatedly.
- In some cases, this speeds up `SlabGenerator.get_slabs` significantly.
 
https://github.com/materialsproject/pymatgen-core/blob/9ef9e152b05a39643d25121c8743a0fffbd02dfd/src/pymatgen/core/surface.py#L1384

### Speedup
The outputs from [demo_hash_speedup.py](https://github.com/user-attachments/files/28058850/demo_hash_speedup.py):
group_structures on 80 structures (36-atom NaCl supercell)
  old hash (composition only): 4.274 s
  new hash (composition + coords): 0.259 s
  speedup: 16.5x


## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes: N/A?
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))