### PR TITLE
Refactor Structure/Molecule I/O dispatch to a plugin registry

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -12,7 +12,6 @@ import functools
 import inspect
 import io
 import itertools
-import json
 import math
 import os
 import re
@@ -20,16 +19,13 @@ import sys
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Literal, cast, get_args, overload
 
 import numpy as np
 import orjson
 from monty.dev import deprecated
-from monty.io import zopen
 from monty.json import MSONable
 from numpy.linalg import norm
-from ruamel.yaml import YAML
 from tabulate import tabulate
 
 # scipy.cluster.hierarchy, scipy.linalg, and scipy.spatial are imported
@@ -2962,9 +2958,9 @@ class IStructure(SiteCollection, MSONable):
             fmt (str): Format to output to. Defaults to JSON unless filename
                 is provided. If specified, it overrides whatever the
                 filename is. Options include "cif", "poscar", "cssr", "json",
-                "xsf", "mcsqs", "prismatic", "yaml", "yml", "fleur-inpgen", "pwmat",
-                "aims".
-                Case insensitive.
+                "xsf", "mcsqs", "prismatic", "yaml", "yml", "fleur-inpgen",
+                "pwmat", "aims", or any format registered via
+                `pymatgen.io.registry`. Case-insensitive.
             **kwargs: Kwargs pass thru to relevant methods. This allows
                 the passing of parameters like `symprec` to the
                 `CifWriter.__init__ method` for generation of symmetric CIFs.
@@ -2973,121 +2969,25 @@ class IStructure(SiteCollection, MSONable):
             str: String representation of structure in given format. If a filename
                 is provided, the same string is written to the file.
         """
+        from pymatgen.io.registry import dispatch_write, get_structure_format
+
         filename, fmt = str(filename), cast("FileFormats", fmt.lower())
 
-        # Default to JSON if filename not specified
+        # Default to JSON if neither filename nor fmt are specified
         if filename == "" and fmt == "":
             fmt = "json"
 
-        if fmt == "cif" or fnmatch(filename.lower(), "*.cif*"):
-            from pymatgen.io.cif import CifWriter
+        try:
+            handler = get_structure_format(name=fmt, filename=filename)
+        except ValueError:
+            if fmt == "" and filename:
+                raise ValueError(f"Format not specified and could not infer from {filename=}") from None
+            if fmt:
+                raise ValueError(f"Invalid {fmt=}, valid options are {get_args(FileFormats)}") from None
+            raise
 
-            writer: Any = CifWriter(self, **kwargs)
-
-        elif fmt == "mcif" or fnmatch(filename.lower(), "*.mcif*"):
-            from pymatgen.io.cif import CifWriter
-
-            writer = CifWriter(self, write_magmoms=True, **kwargs)
-
-        elif fmt == "poscar" or fnmatch(filename, "*POSCAR*"):
-            from pymatgen.io.vasp import Poscar
-
-            writer = Poscar(self, **kwargs)
-
-        elif fmt == "cssr" or fnmatch(filename.lower(), "*.cssr*"):
-            from pymatgen.io.cssr import Cssr
-
-            writer = Cssr(self)
-
-        elif fmt == "json" or fnmatch(filename.lower(), "*.json*"):
-            json_str = (
-                json.dumps(self.as_dict(), **kwargs)
-                if kwargs
-                else orjson.dumps(self.as_dict(), option=orjson.OPT_SERIALIZE_NUMPY).decode()
-            )
-
-            if filename:
-                with zopen(filename, mode="wt", encoding="utf-8") as file:
-                    file.write(json_str)  # type:ignore[arg-type]
-            return json_str
-
-        elif fmt == "xsf" or fnmatch(filename.lower(), "*.xsf*"):
-            from pymatgen.io.xcrysden import XSF
-
-            res_str = XSF(self).to_str()
-            if filename:
-                with zopen(filename, mode="wt", encoding="utf-8") as file:
-                    file.write(res_str)  # type:ignore[arg-type]
-            return res_str
-
-        elif (
-            fmt == "mcsqs"
-            or fnmatch(filename, "*rndstr.in*")
-            or fnmatch(filename, "*lat.in*")
-            or fnmatch(filename, "*bestsqs*")
-        ):
-            from pymatgen.io.atat import Mcsqs
-
-            res_str = Mcsqs(self).to_str()
-            if filename:
-                with zopen(filename, mode="wt", encoding="ascii") as file:
-                    file.write(res_str)  # type:ignore[arg-type]
-            return res_str
-
-        elif fmt == "prismatic" or fnmatch(filename, "*prismatic*"):
-            from pymatgen.io.prismatic import Prismatic
-
-            return Prismatic(self).to_str()
-
-        elif fmt in ("yaml", "yml") or fnmatch(filename, "*.yaml*") or fnmatch(filename, "*.yml*"):
-            yaml = YAML()
-            str_io = io.StringIO()
-            yaml.dump(self.as_dict(), str_io)
-            yaml_str = str_io.getvalue()
-            if filename:
-                with zopen(filename, mode="wt", encoding="utf-8") as file:
-                    file.write(yaml_str)  # type:ignore[arg-type]
-            return yaml_str
-
-        elif fmt == "aims" or fnmatch(filename, "geometry.in"):
-            from pymatgen.io.aims.inputs import AimsGeometryIn
-
-            geom_in = AimsGeometryIn.from_structure(self)
-            if filename:
-                with zopen(filename, mode="wt", encoding="utf-8") as file:
-                    file.write(geom_in.get_header(filename))  # type:ignore[arg-type]
-                    file.write(geom_in.content)  # type:ignore[arg-type]
-                    file.write("\n")  # type:ignore[arg-type]
-            return geom_in.content
-
-        # fleur support implemented in external namespace pkg https://github.com/JuDFTteam/pymatgen-io-fleur
-        elif fmt == "fleur-inpgen" or fnmatch(filename, "*.in*"):
-            from pymatgen.io.fleur import FleurInput
-
-            writer = FleurInput(self, **kwargs)
-
-        elif fmt == "res" or fnmatch(filename, "*.res"):
-            from pymatgen.io.res import ResIO
-
-            res_str = ResIO.structure_to_str(self)
-            if filename:
-                with zopen(filename, mode="wt", encoding="utf-8") as file:
-                    file.write(res_str)  # type:ignore[arg-type]
-            return res_str
-
-        elif fmt == "pwmat" or fnmatch(filename.lower(), "*.pwmat") or fnmatch(filename.lower(), "*.config"):
-            from pymatgen.io.pwmat import AtomConfig
-
-            writer = AtomConfig(self, **kwargs)
-
-        else:
-            if fmt == "":
-                raise ValueError(f"Format not specified and could not infer from {filename=}")
-            raise ValueError(f"Invalid {fmt=}, valid options are {get_args(FileFormats)}")
-
-        if filename:
-            writer.write_file(filename)
-        return str(writer)
+        result = dispatch_write(handler, self, filename, **kwargs)
+        return result or ""
 
     @classmethod
     def from_id(cls, id_, source: Literal["Materials Project", "COD"] = "Materials Project", **kwargs) -> Structure:
@@ -3117,24 +3017,11 @@ class IStructure(SiteCollection, MSONable):
     def _filter_kwargs(func: Callable, kwargs: dict) -> dict:
         """Filter kwargs to only those accepted by func, warning about any removed.
 
-        Args:
-            func: The callable to inspect.
-            kwargs: The kwargs dict to filter.
-
-        Returns:
-            dict of kwargs supported by func.
+        Kept as a backward-compatible shim around `pymatgen.io.registry.filter_kwargs`.
         """
-        params = inspect.signature(func).parameters
-        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
-            return kwargs
-        supported = {k: v for k, v in kwargs.items() if k in params}
-        unsupported = kwargs.keys() - supported.keys()
-        if unsupported:
-            warnings.warn(
-                f"The following kwargs are not supported by {func.__qualname__} and will be ignored: {unsupported}",
-                stacklevel=3,
-            )
-        return supported
+        from pymatgen.io.registry import filter_kwargs
+
+        return filter_kwargs(func, kwargs, stacklevel=4)
 
     @classmethod
     def from_str(  # type:ignore[override]
@@ -3151,9 +3038,10 @@ class IStructure(SiteCollection, MSONable):
         Args:
             input_string (str): String to parse.
             fmt (str): A file format specification. One of "cif", "poscar", "cssr",
-                "json", "yaml", "yml", "xsf", "mcsqs", "res".
+                "json", "yaml", "yml", "xsf", "mcsqs", "res", "pwmat", "aims",
+                "fleur-inpgen", or any format registered via `pymatgen.io.registry`.
             primitive (bool): Whether to find a primitive cell. Defaults to
-                False.
+                False. Only honored by formats that support it (notably CIF).
             sort (bool): Whether to sort the sites in accordance to the default
                 ordering criteria, i.e., electronegativity.
             merge_tol (float): If this is some positive number, sites that
@@ -3164,73 +3052,14 @@ class IStructure(SiteCollection, MSONable):
         Returns:
             IStructure | Structure
         """
-        fmt_low = fmt.lower()
-        if fmt_low == "cif":
-            from pymatgen.io.cif import CifParser
+        from pymatgen.io.registry import dispatch_read_str, get_structure_format
 
-            parser = CifParser.from_str(input_string, **cls._filter_kwargs(CifParser.from_str, kwargs))
-            struct = parser.parse_structures(primitive=primitive)[0]
-        elif fmt_low == "poscar":
-            from pymatgen.io.vasp import Poscar
+        try:
+            handler = get_structure_format(name=fmt.lower())
+        except ValueError:
+            raise ValueError(f"Invalid {fmt=}, valid options are {get_args(FileFormats)}") from None
 
-            struct = Poscar.from_str(
-                input_string, default_names=None, read_velocities=False, **cls._filter_kwargs(Poscar.from_str, kwargs)
-            ).structure
-        elif fmt_low == "cssr":
-            from pymatgen.io.cssr import Cssr
-
-            cssr = Cssr.from_str(input_string, **cls._filter_kwargs(Cssr.from_str, kwargs))
-            struct = cssr.structure  # type:ignore[assignment]
-        elif fmt_low == "json":
-            dct = orjson.loads(input_string)
-            struct = Structure.from_dict(dct)
-        elif fmt_low in ("yaml", "yml"):
-            yaml = YAML()
-            dct = yaml.load(input_string)
-            struct = Structure.from_dict(dct)
-        elif fmt_low == "xsf":
-            from pymatgen.io.xcrysden import XSF
-
-            xsf = XSF.from_str(input_string, **cls._filter_kwargs(XSF.from_str, kwargs))
-            if xsf.structure is None:
-                raise ValueError("XSF data does not contain a structure; use XSF.from_str for grids or band data")
-            if isinstance(xsf.structure, Molecule):
-                raise ValueError("XSF data contains a Molecule; use pymatgen.io.xcrysden.XSF for molecular data")
-            struct = xsf.structure
-            struct.properties.update(xsf.structure_properties())
-        elif fmt_low == "mcsqs":
-            from pymatgen.io.atat import Mcsqs
-
-            struct = Mcsqs.structure_from_str(input_string, **cls._filter_kwargs(Mcsqs.structure_from_str, kwargs))
-        elif fmt == "aims":
-            from pymatgen.io.aims.inputs import AimsGeometryIn
-
-            struct = AimsGeometryIn.from_str(input_string).structure  # type:ignore[assignment]
-        # fleur support implemented in external namespace pkg https://github.com/JuDFTteam/pymatgen-io-fleur
-        elif fmt == "fleur-inpgen":
-            from pymatgen.io.fleur import FleurInput
-
-            if kwargs:
-                warnings.warn(
-                    f"kwargs {set(kwargs)} cannot be validated for fleur-inpgen and will be passed through as-is.",
-                    stacklevel=2,
-                )
-            struct = FleurInput.from_string(input_string, inpgen_input=True, **kwargs).structure
-        elif fmt == "fleur":
-            from pymatgen.io.fleur import FleurInput
-
-            struct = FleurInput.from_string(input_string, inpgen_input=False).structure
-        elif fmt == "res":
-            from pymatgen.io.res import ResIO
-
-            struct = ResIO.structure_from_str(input_string, **cls._filter_kwargs(ResIO.structure_from_str, kwargs))
-        elif fmt == "pwmat":
-            from pymatgen.io.pwmat import AtomConfig
-
-            struct = AtomConfig.from_str(input_string, **cls._filter_kwargs(AtomConfig.from_str, kwargs)).structure
-        else:
-            raise ValueError(f"Invalid {fmt=}, valid options are {get_args(FileFormats)}")
-
+        struct = dispatch_read_str(handler, input_string, primitive=primitive, **kwargs)
         if sort:
             struct = struct.get_sorted_structure()
         if merge_tol:
@@ -3249,11 +3078,13 @@ class IStructure(SiteCollection, MSONable):
         """Read a structure from a file. For example, anything ending in
         a "cif" is assumed to be a Crystallographic Information Format file.
         Supported formats include CIF, POSCAR/CONTCAR, CHGCAR, LOCPOT,
-        vasprun.xml, CSSR, Netcdf and pymatgen's JSON-serialized structures.
+        vasprun.xml, CSSR, NetCDF, pymatgen's JSON-serialized structures, and
+        any format registered via `pymatgen.io.registry`.
 
         Args:
             filename (PathLike): The file to read.
             primitive (bool): Whether to convert to a primitive cell. Defaults to False.
+                Only honored by formats that support it (notably CIF).
             sort (bool): Whether to sort sites. Default to False.
             merge_tol (float): If this is some positive number, sites that are within merge_tol from each other will be
                 merged. Usually 0.01 should be enough to deal with common numerical issues.
@@ -3263,136 +3094,15 @@ class IStructure(SiteCollection, MSONable):
         Returns:
             Structure.
         """
+        from pymatgen.io.registry import dispatch_read_file, get_structure_format
+
         filename = str(filename)
-        if filename.endswith(".nc"):
-            # Read Structure from a netcdf file.
-            from pymatgen.io.abinit.netcdf import structure_from_ncdata
+        try:
+            handler = get_structure_format(filename=filename)
+        except ValueError:
+            raise ValueError(f"Unrecognized extension in {filename=}") from None
 
-            struct = structure_from_ncdata(filename, cls=cls)
-            if sort:
-                struct = struct.get_sorted_structure()
-            return struct
-
-        fname = os.path.basename(filename)
-        if fnmatch(fname.lower(), "*.cif*") or fnmatch(fname.lower(), "*.mcif*"):
-            with zopen(filename, mode="rt", errors="replace", encoding="utf-8") as file:
-                contents: str = file.read()  # type:ignore[assignment]
-            return cls.from_str(
-                contents,
-                fmt="cif",
-                primitive=primitive,
-                sort=sort,
-                merge_tol=merge_tol,
-                **kwargs,
-            )
-        if fnmatch(fname, "*POSCAR*") or fnmatch(fname, "*CONTCAR*") or fnmatch(fname, "*.vasp"):
-            with zopen(filename, mode="rt", errors="replace", encoding="utf-8") as file:
-                contents = file.read()  # type:ignore[assignment]
-            struct = cls.from_str(
-                contents,
-                fmt="poscar",
-                primitive=primitive,
-                sort=sort,
-                merge_tol=merge_tol,
-                **kwargs,
-            )
-
-        elif fnmatch(fname, "CHGCAR*") or fnmatch(fname, "LOCPOT*"):
-            from pymatgen.io.vasp import Chgcar
-
-            struct = Chgcar.from_file(filename, **kwargs).structure
-        elif fnmatch(fname, "vasprun*.xml*"):
-            from pymatgen.io.vasp import Vasprun
-
-            struct = Vasprun(filename, **kwargs).final_structure
-        elif fnmatch(fname.lower(), "*.cssr*"):
-            with zopen(filename, mode="rt", errors="replace", encoding="utf-8") as file:
-                contents = file.read()  # type:ignore[assignment]
-            return cls.from_str(
-                contents,
-                fmt="cssr",
-                primitive=primitive,
-                sort=sort,
-                merge_tol=merge_tol,
-                **kwargs,
-            )
-        elif fnmatch(fname, "*.json*") or fnmatch(fname, "*.mson*"):
-            with zopen(filename, mode="rt", errors="replace", encoding="utf-8") as file:
-                contents = file.read()  # type:ignore[assignment]
-            return cls.from_str(
-                contents,
-                fmt="json",
-                primitive=primitive,
-                sort=sort,
-                merge_tol=merge_tol,
-                **kwargs,
-            )
-        elif fnmatch(fname, "*.yaml*") or fnmatch(fname, "*.yml*"):
-            with zopen(filename, mode="rt", errors="replace", encoding="utf-8") as file:
-                contents = file.read()  # type:ignore[assignment]
-            return cls.from_str(
-                contents,
-                fmt="yaml",
-                primitive=primitive,
-                sort=sort,
-                merge_tol=merge_tol,
-                **kwargs,
-            )
-        elif fnmatch(fname, "*.xsf*"):
-            from pymatgen.io.xcrysden import XSF
-
-            with zopen(filename, mode="rb") as file:
-                xsf = XSF.parse_file(file, **cls._filter_kwargs(XSF.parse_file, kwargs))
-            if xsf.structure is None:
-                raise ValueError("XSF data does not contain a structure; use XSF.from_file for grids or band data")
-            if isinstance(xsf.structure, Molecule):
-                raise ValueError("XSF data contains a Molecule; use pymatgen.io.xcrysden.XSF for molecular data")
-            struct = xsf.structure
-            struct.properties.update(xsf.structure_properties())
-        elif fnmatch(fname, "input*.xml"):
-            from pymatgen.io.exciting import ExcitingInput
-
-            return ExcitingInput.from_file(filename, **kwargs).structure  # type:ignore[assignment, return-value]
-        elif fnmatch(fname, "*rndstr.in*") or fnmatch(fname, "*lat.in*") or fnmatch(fname, "*bestsqs*"):
-            with zopen(filename, mode="rt", errors="replace", encoding="utf-8") as file:
-                contents = file.read()  # type:ignore[assignment]
-            return cls.from_str(
-                contents,
-                fmt="mcsqs",
-                primitive=primitive,
-                sort=sort,
-                merge_tol=merge_tol,
-                **kwargs,
-            )
-        elif fnmatch(fname, "CTRL*"):
-            from pymatgen.io.lmto import LMTOCtrl
-
-            return LMTOCtrl.from_file(filename=filename, **kwargs).structure  # type:ignore[assignment,return-value]
-        elif fnmatch(fname, "geometry.in*"):
-            with zopen(filename, mode="rt", errors="replace", encoding="utf-8") as file:
-                contents = file.read()  # type:ignore[assignment]
-            return cls.from_str(
-                contents,
-                fmt="aims",
-                primitive=primitive,
-                sort=sort,
-                merge_tol=merge_tol,
-                **kwargs,
-            )
-        elif fnmatch(fname, "inp*.xml") or fnmatch(fname, "*.in*") or fnmatch(fname, "inp_*"):
-            from pymatgen.io.fleur import FleurInput
-
-            struct = FleurInput.from_file(filename, **kwargs).structure
-        elif fnmatch(fname, "*.res"):
-            from pymatgen.io.res import ResIO
-
-            struct = ResIO.structure_from_file(filename, **kwargs)
-        elif fnmatch(fname.lower(), "*.config*") or fnmatch(fname.lower(), "*.pwmat*"):
-            from pymatgen.io.pwmat import AtomConfig
-
-            struct = AtomConfig.from_file(filename, **kwargs).structure
-        else:
-            raise ValueError(f"Unrecognized extension in {filename=}")
+        struct = dispatch_read_file(handler, filename, primitive=primitive, **kwargs)
         if sort:
             struct = struct.get_sorted_structure()
         if merge_tol:
@@ -4092,57 +3802,30 @@ class IMolecule(SiteCollection, MSONable):
                 is provided. If fmt is specifies, it overrides whatever the
                 filename is. Options include "xyz", "gjf", "g03", "json". If
                 you have OpenBabel installed, any of the formats supported by
-                OpenBabel. Non-case sensitive.
+                OpenBabel. Any format registered via `pymatgen.io.registry`
+                is also accepted. Case-insensitive.
 
         Returns:
             str: String representation of molecule in given format. If a filename
                 is provided, the same string is written to the file.
         """
+        from pymatgen.io.registry import dispatch_write, get_molecule_format
+
         filename = str(filename)
         fmt = fmt.lower()
 
-        writer: Any
-        if fmt == "xyz" or fnmatch(filename.lower(), "*.xyz*"):
-            from pymatgen.io.xyz import XYZ
+        if not filename and not fmt:
+            fmt = "json"
 
-            writer = XYZ(self)
-
-        elif any(fmt == ext or fnmatch(filename.lower(), f"*.{ext}*") for ext in ("gjf", "g03", "g09", "com", "inp")):
-            from pymatgen.io.gaussian import GaussianInput
-
-            writer = GaussianInput(self)
-
-        elif fmt == "json" or fnmatch(filename, "*.json*") or fnmatch(filename, "*.mson*"):
-            json_str = orjson.dumps(self.as_dict(), option=orjson.OPT_SERIALIZE_NUMPY).decode()
-
-            if filename:
-                with zopen(filename, mode="wt", encoding="utf-8") as file:
-                    file.write(json_str)  # type:ignore[arg-type]
-            return json_str
-
-        elif fmt in {"yaml", "yml"} or fnmatch(filename, "*.yaml*") or fnmatch(filename, "*.yml*"):
-            yaml = YAML()
-            str_io = io.StringIO()
-            yaml.dump(self.as_dict(), str_io)
-            yaml_str = str_io.getvalue()
-            if filename:
-                with zopen(filename, mode="wt", encoding="utf-8") as file:
-                    file.write(yaml_str)  # type:ignore[arg-type]
-            return yaml_str
-
-        else:
-            from pymatgen.io.babel import BabelMolAdaptor
-
+        # If filename has a babel-only extension but no fmt was specified,
+        # infer the format from the extension (preserves legacy behavior).
+        if not fmt and filename:
             match = re.search(r"\.(pdb|mol|mdl|sdf|sd|ml2|sy2|mol2|cml|mrv)", filename.lower())
-            if not fmt and match:
+            if match:
                 fmt = match[1]
-            writer = BabelMolAdaptor(self)
-            return writer.write_file(filename, file_format=fmt)
 
-        if filename:
-            writer.write_file(filename)
-
-        return str(writer)
+        handler = get_molecule_format(name=fmt, filename=filename)
+        return dispatch_write(handler, self, filename)
 
     @classmethod
     def from_str(  # type:ignore[override]
@@ -4154,53 +3837,29 @@ class IMolecule(SiteCollection, MSONable):
 
         Args:
             input_string (str): String to parse.
-            fmt (str): Format to output to. Defaults to JSON unless filename
-                is provided. If fmt is specifies, it overrides whatever the
-                filename is. Options include "xyz", "gjf", "g03", "json". If
-                you have OpenBabel installed, any of the formats supported by
-                OpenBabel. Non-case sensitive.
+            fmt (str): Format to output to. Options include "xyz", "gjf", "g03",
+                "json", or any format registered via `pymatgen.io.registry`.
+                If you have OpenBabel installed, any of the formats supported by
+                OpenBabel. Case-insensitive.
 
         Returns:
             IMolecule or Molecule.
         """
-        fmt = cast(
-            "Literal['xyz', 'gjf', 'g03', 'g09', 'com', 'inp', 'json', 'yaml']",
-            fmt.lower(),
-        )
+        from pymatgen.io.registry import dispatch_read_str, get_molecule_format
 
-        if fmt == "xyz":
-            from pymatgen.io.xyz import XYZ
-
-            mol = XYZ.from_str(input_string).molecule
-
-        elif fmt in {"gjf", "g03", "g09", "com", "inp"}:
-            from pymatgen.io.gaussian import GaussianInput
-
-            mol = GaussianInput.from_str(input_string).molecule
-
-        elif fmt == "json":
-            dct = orjson.loads(input_string)
-            return cls.from_dict(dct)
-
-        elif fmt in {"yaml", "yml"}:
-            yaml = YAML()
-            dct = yaml.load(input_string)
-            return cls.from_dict(dct)
-
-        else:
-            from pymatgen.io.babel import BabelMolAdaptor
-
-            mol = BabelMolAdaptor.from_str(input_string, file_format=fmt).pymatgen_mol
-
+        handler = get_molecule_format(name=fmt.lower())
+        mol = dispatch_read_str(handler, input_string)
+        if isinstance(mol, dict):  # pragma: no cover — defensive; readers should return Molecules
+            return cls.from_dict(mol)
         return cls.from_sites(mol, properties=mol.properties)
 
     @classmethod
     def from_file(cls, filename: PathLike) -> IMolecule | Molecule:  # type:ignore[override]
         """Read a molecule from a file. Supported formats include xyz,
-        gaussian input (gjf|g03|g09|com|inp), Gaussian output (.out|and
-        pymatgen's JSON-serialized molecules. Using openbabel,
-        many more extensions are supported but requires openbabel to be
-        installed.
+        gaussian input (gjf|g03|g09|com|inp), Gaussian output (.out, .lis, .log),
+        pymatgen's JSON-serialized molecules, and any format registered via
+        `pymatgen.io.registry`. Using openbabel, many more extensions are
+        supported but requires openbabel to be installed.
 
         Args:
             filename (PathLike): The file to read.
@@ -4208,37 +3867,19 @@ class IMolecule(SiteCollection, MSONable):
         Returns:
             Molecule
         """
+        from pymatgen.io.registry import dispatch_read_file, get_molecule_format
+
         filename = str(filename)
-        fname = filename.lower()
+        try:
+            handler = get_molecule_format(filename=filename)
+        except ValueError:
+            raise ValueError("Cannot determine file type.") from None
 
-        with zopen(filename, mode="rt", encoding="utf-8") as file:
-            contents: str = cast("str", file.read())
-
-        if fnmatch(fname, "*.xyz*"):
-            return cls.from_str(contents, fmt="xyz")
-
-        if any(fnmatch(fname.lower(), f"*.{r}*") for r in ("gjf", "g03", "g09", "com", "inp")):
-            return cls.from_str(contents, fmt="g09")
-
-        if any(fnmatch(fname.lower(), f"*.{r}*") for r in ("out", "lis", "log")):
-            from pymatgen.io.gaussian import GaussianOutput
-
-            return GaussianOutput(filename).final_structure
-
-        if fnmatch(fname, "*.json*") or fnmatch(fname, "*.mson*"):
-            return cls.from_str(contents, fmt="json")
-
-        if fnmatch(fname, "*.yaml*") or fnmatch(filename, "*.yml*"):
-            return cls.from_str(contents, fmt="yaml")
-
-        if match := re.search(r"\.(pdb|mol|mdl|sdf|sd|ml2|sy2|mol2|cml|mrv)", filename.lower()):
-            from pymatgen.io.babel import BabelMolAdaptor
-
-            new = BabelMolAdaptor.from_file(filename, match[1]).pymatgen_mol
-            new.__class__ = cls
-            return new
-
-        raise ValueError("Cannot determine file type.")
+        new = dispatch_read_file(handler, filename)
+        if isinstance(new, dict):  # pragma: no cover — defensive
+            return cls.from_dict(new)
+        new.__class__ = cls
+        return new
 
 
 class Structure(IStructure, collections.abc.MutableSequence):

--- a/src/pymatgen/io/abinit/netcdf.py
+++ b/src/pymatgen/io/abinit/netcdf.py
@@ -501,3 +501,36 @@ class AbinitHeader(AttrDict):
     @deprecated(to_str)
     def to_string(self, *args, **kwargs):
         return self.to_str(*args, **kwargs)
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <- ABINIT NetCDF (read-only, binary)
+# ----------------------------------------------------------------------------
+
+
+def _abinit_nc_read_file(filename: str, **kwargs):
+    from pymatgen.core.structure import Structure
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return structure_from_ncdata(
+        filename,
+        cls=Structure,
+        **filter_kwargs(structure_from_ncdata, kwargs),
+    )
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="abinit-nc",
+            patterns=("*.nc",),
+            read_file=_abinit_nc_read_file,
+            binary=True,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/atat.py
+++ b/src/pymatgen/io/atat.py
@@ -139,3 +139,35 @@ class Mcsqs:
             all_species.append(species)
 
         return Structure(lattice, all_species, all_coords)
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <-> mcsqs (rndstr.in / lat.in / bestsqs)
+# ----------------------------------------------------------------------------
+
+
+def _mcsqs_read_str(input_string: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return Mcsqs.structure_from_str(input_string, **filter_kwargs(Mcsqs.structure_from_str, kwargs))
+
+
+def _mcsqs_write_str(structure, **kwargs) -> str:
+    return Mcsqs(structure).to_str()
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="mcsqs",
+            patterns=("*rndstr.in*", "*lat.in*", "*bestsqs*"),
+            read_str=_mcsqs_read_str,
+            write_str=_mcsqs_write_str,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/babel.py
+++ b/src/pymatgen/io/babel.py
@@ -367,3 +367,94 @@ class BabelMolAdaptor:
         """
         mols = pybel.readstring(file_format, string_data)
         return cls(mols.OBMol)
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Molecule <-> OpenBabel-supported formats
+# ----------------------------------------------------------------------------
+
+# Extensions BabelMolAdaptor handles directly. Each is registered as its own
+# format; filename glob matching also covers compressed variants ("*.pdb*").
+_BABEL_FORMATS: tuple[str, ...] = (
+    "pdb",
+    "mol",
+    "mdl",
+    "sdf",
+    "sd",
+    "ml2",
+    "sy2",
+    "mol2",
+    "cml",
+    "mrv",
+)
+
+
+def _make_babel_read_str(file_format: str):
+    def _read_str(input_string: str, **kwargs):
+        return BabelMolAdaptor.from_str(input_string, file_format=file_format, **kwargs).pymatgen_mol
+
+    return _read_str
+
+
+def _make_babel_read_file(file_format: str):
+    def _read_file(filename: str, **kwargs):
+        return BabelMolAdaptor.from_file(filename, file_format=file_format, **kwargs).pymatgen_mol
+
+    return _read_file
+
+
+def _make_babel_write_str(file_format: str):
+    def _write_str(molecule, **kwargs):
+        # BabelMolAdaptor has no string output; serialize via a temp file.
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=f".{file_format}", delete=False) as fh:
+            tmp = fh.name
+        try:
+            BabelMolAdaptor(molecule).write_file(tmp, file_format=file_format)
+            with open(tmp, encoding="utf-8") as f:
+                return f.read()
+        finally:
+            os.unlink(tmp)
+
+    return _write_str
+
+
+def _make_babel_write_file(file_format: str):
+    def _write_file(molecule, filename, **kwargs):
+        BabelMolAdaptor(molecule).write_file(filename, file_format=file_format)
+
+    return _write_file
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import MoleculeFormat, register_molecule_format
+
+    for fmt in _BABEL_FORMATS:
+        register_molecule_format(
+            MoleculeFormat(
+                name=fmt,
+                patterns=(f"*.{fmt}*",),
+                read_str=_make_babel_read_str(fmt),
+                read_file=_make_babel_read_file(fmt),
+                write_str=_make_babel_write_str(fmt),
+                write_file=_make_babel_write_file(fmt),
+            )
+        )
+    # Generic "babel" alias that uses the caller-supplied file_format kwarg.
+    register_molecule_format(
+        MoleculeFormat(
+            name="babel",
+            patterns=(),
+            read_str=lambda s, file_format="xyz", **kw: (
+                BabelMolAdaptor.from_str(s, file_format=file_format, **kw).pymatgen_mol
+            ),
+            read_file=lambda fn, file_format="xyz", **kw: (
+                BabelMolAdaptor.from_file(fn, file_format=file_format, **kw).pymatgen_mol
+            ),
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/cif.py
+++ b/src/pymatgen/io/cif.py
@@ -1793,3 +1793,58 @@ class CifWriter:
         """Write the CIF file."""
         with zopen(filename, mode=mode, encoding="utf-8") as file:
             file.write(str(self))  # type:ignore[arg-type]
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <-> CIF / mCIF
+# ----------------------------------------------------------------------------
+
+
+def _cif_read_str(cif_string: str, *, primitive: bool = False, **kwargs):
+    """Adapter for `Structure.from_str(s, fmt="cif")` / `"mcif"`."""
+    from pymatgen.io.registry import filter_kwargs
+
+    parser = CifParser.from_str(cif_string, **filter_kwargs(CifParser.from_str, kwargs))
+    return parser.parse_structures(primitive=primitive)[0]
+
+
+def _cif_write_str(structure, **kwargs) -> str:
+    return str(CifWriter(structure, **kwargs))
+
+
+def _cif_write_file(structure, filename, **kwargs) -> None:
+    CifWriter(structure, **kwargs).write_file(filename)
+
+
+def _mcif_write_str(structure, **kwargs) -> str:
+    return str(CifWriter(structure, write_magmoms=True, **kwargs))
+
+
+def _mcif_write_file(structure, filename, **kwargs) -> None:
+    CifWriter(structure, write_magmoms=True, **kwargs).write_file(filename)
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="cif",
+            patterns=("*.cif*",),
+            read_str=_cif_read_str,
+            write_str=_cif_write_str,
+            write_file=_cif_write_file,
+        )
+    )
+    register_structure_format(
+        StructureFormat(
+            name="mcif",
+            patterns=("*.mcif*",),
+            read_str=_cif_read_str,
+            write_str=_mcif_write_str,
+            write_file=_mcif_write_file,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/cssr.py
+++ b/src/pymatgen/io/cssr.py
@@ -102,3 +102,40 @@ class Cssr:
         """
         with zopen(filename, mode="rt", encoding="utf-8") as file:
             return cls.from_str(file.read())  # type:ignore[arg-type]
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <-> CSSR
+# ----------------------------------------------------------------------------
+
+
+def _cssr_read_str(input_string: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return Cssr.from_str(input_string, **filter_kwargs(Cssr.from_str, kwargs)).structure
+
+
+def _cssr_write_str(structure, **kwargs) -> str:
+    return str(Cssr(structure, **kwargs))
+
+
+def _cssr_write_file(structure, filename, **kwargs) -> None:
+    Cssr(structure, **kwargs).write_file(filename)
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="cssr",
+            patterns=("*.cssr*",),
+            read_str=_cssr_read_str,
+            write_str=_cssr_write_str,
+            write_file=_cssr_write_file,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/exciting/inputs.py
+++ b/src/pymatgen/io/exciting/inputs.py
@@ -418,3 +418,38 @@ class ExcitingInput(MSONable):
 
             else:
                 warnings.warn(f"cannot deal with {key} = {value}", stacklevel=2)
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <- exciting input.xml (read-only)
+# ----------------------------------------------------------------------------
+
+
+def _exciting_read_str(input_string: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return ExcitingInput.from_str(input_string, **filter_kwargs(ExcitingInput.from_str, kwargs)).structure
+
+
+def _exciting_read_file(filename: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return ExcitingInput.from_file(filename, **filter_kwargs(ExcitingInput.from_file, kwargs)).structure
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="exciting",
+            patterns=("input*.xml",),
+            read_str=_exciting_read_str,
+            read_file=_exciting_read_file,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/gaussian.py
+++ b/src/pymatgen/io/gaussian.py
@@ -1333,3 +1333,61 @@ class GaussianOutput:
             link0_parameters=link0_parameters,
             dieze_tag=dieze_tag,
         )
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Molecule <-> Gaussian input / Gaussian output
+# ----------------------------------------------------------------------------
+
+
+def _gaussian_read_str(input_string: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    return GaussianInput.from_str(input_string, **filter_kwargs(GaussianInput.from_str, kwargs)).molecule
+
+
+def _gaussian_write_str(molecule, **kwargs) -> str:
+    return str(GaussianInput(molecule, **kwargs))
+
+
+def _gaussian_write_file(molecule, filename, **kwargs) -> None:
+    GaussianInput(molecule, **kwargs).write_file(filename)
+
+
+def _gaussian_out_read_file(filename: str, **kwargs):
+    return GaussianOutput(filename).final_structure
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import MoleculeFormat, register_molecule_format
+
+    register_molecule_format(
+        MoleculeFormat(
+            name="gaussian",
+            patterns=("*.gjf*", "*.g03*", "*.g09*", "*.com*", "*.inp*"),
+            read_str=_gaussian_read_str,
+            write_str=_gaussian_write_str,
+            write_file=_gaussian_write_file,
+        )
+    )
+    # Common aliases for the gaussian input format.
+    for alias in ("gjf", "g03", "g09", "com", "inp"):
+        register_molecule_format(
+            MoleculeFormat(
+                name=alias,
+                patterns=(f"*.{alias}*",),
+                read_str=_gaussian_read_str,
+                write_str=_gaussian_write_str,
+                write_file=_gaussian_write_file,
+            )
+        )
+    register_molecule_format(
+        MoleculeFormat(
+            name="gaussian-out",
+            patterns=("*.out*", "*.lis*", "*.log*"),
+            read_file=_gaussian_out_read_file,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/lmto.py
+++ b/src/pymatgen/io/lmto.py
@@ -402,3 +402,30 @@ class LMTOCopl:
         species = tuple(re.split(r"\d+", spec)[0] for spec in sites[:3:2])
         label = f"{species[0]}{site_indices[0] + 1}-{species[1]}{site_indices[1] + 1}"
         return label, length, site_indices
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <-> LMTO CTRL
+# ----------------------------------------------------------------------------
+
+
+def _lmto_read_file(filename: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return LMTOCtrl.from_file(filename=filename, **filter_kwargs(LMTOCtrl.from_file, kwargs)).structure
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="lmto",
+            patterns=("CTRL*",),
+            read_file=_lmto_read_file,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/prismatic.py
+++ b/src/pymatgen/io/prismatic.py
@@ -39,3 +39,27 @@ class Prismatic:
         lines.append("-1")
 
         return "\n".join(lines)
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure -> Prismatic (write-only)
+# ----------------------------------------------------------------------------
+
+
+def _prismatic_write_str(structure, **kwargs) -> str:
+    return Prismatic(structure, **kwargs).to_str()
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="prismatic",
+            patterns=("*prismatic*",),
+            write_str=_prismatic_write_str,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/pwmat/__init__.py
+++ b/src/pymatgen/io/pwmat/__init__.py
@@ -4,3 +4,47 @@ from __future__ import annotations
 
 from .inputs import AtomConfig
 from .outputs import DosSpin, Movement, OutFermi, Report
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <-> PWmat atom.config
+# ----------------------------------------------------------------------------
+
+
+def _pwmat_read_str(input_string: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return AtomConfig.from_str(input_string, **filter_kwargs(AtomConfig.from_str, kwargs)).structure
+
+
+def _pwmat_read_file(filename: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return AtomConfig.from_file(filename, **filter_kwargs(AtomConfig.from_file, kwargs)).structure
+
+
+def _pwmat_write_str(structure, **kwargs) -> str:
+    return str(AtomConfig(structure, **kwargs))
+
+
+def _pwmat_write_file(structure, filename, **kwargs) -> None:
+    AtomConfig(structure, **kwargs).write_file(filename)
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="pwmat",
+            patterns=("*.pwmat*", "*.config*"),
+            read_str=_pwmat_read_str,
+            read_file=_pwmat_read_file,
+            write_str=_pwmat_write_str,
+            write_file=_pwmat_write_file,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/registry.py
+++ b/src/pymatgen/io/registry.py
@@ -206,7 +206,6 @@ _BUILTIN_STRUCTURE_FILENAME_PRIORITY: tuple[tuple[str, str], ...] = (
     # For `to`: "prismatic" is dispatched by fmt= today and would match here
     # only if a user names their file with "prismatic" in it.
     ("prismatic", "*prismatic*"),
-    ("aims", "geometry.in"),
 )
 
 _BUILTIN_MOLECULE_FILENAME_PRIORITY: tuple[tuple[str, str], ...] = (

--- a/src/pymatgen/io/registry.py
+++ b/src/pymatgen/io/registry.py
@@ -418,8 +418,6 @@ def get_structure_format(*, name: str = "", filename: str = "") -> StructureForm
         _ensure_loaded_structure(name)
         if name in _STRUCTURE_REGISTRY:
             return _STRUCTURE_REGISTRY[name]
-        if filename:
-            raise ValueError(f"Invalid fmt={name!r}")
         raise ValueError(f"Invalid fmt={name!r}")
 
     if not filename:

--- a/src/pymatgen/io/registry.py
+++ b/src/pymatgen/io/registry.py
@@ -1,0 +1,738 @@
+"""Plugin registry for `Structure` and `Molecule` file-format handlers.
+
+`IStructure.from_file`/`from_str`/`to` (and the `IMolecule` counterparts)
+dispatch through this registry instead of carrying a hard-coded if/elif chain.
+Each `pymatgen.io.<format>` module owns its own read/write glue and registers
+it here at module-import time:
+
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    def _read_str(s, *, primitive=False, **kwargs):
+        ...
+
+    register_structure_format(StructureFormat(
+        name="cif",
+        patterns=("*.cif*", "*.mcif*"),
+        read_str=_read_str,
+        write_str=_write_str,
+        write_file=_write_file,
+    ))
+
+Built-in formats are discovered lazily via `_BUILTIN_STRUCTURE_MODULES` and
+`_BUILTIN_MOLECULE_MODULES`: the first lookup of a format name (or matching
+filename) triggers `importlib.import_module` of the io module, which performs
+its registration as a side effect. External packages can additionally declare
+the entry-point groups `pymatgen.io.structure_formats` and
+`pymatgen.io.molecule_formats` in their `pyproject.toml`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+import warnings
+from dataclasses import dataclass, field
+from fnmatch import fnmatch
+from typing import TYPE_CHECKING
+
+from monty.io import zopen
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pymatgen.core.structure import IMolecule, IStructure
+
+
+__all__ = (
+    "MoleculeFormat",
+    "StructureFormat",
+    "filter_kwargs",
+    "get_molecule_format",
+    "get_structure_format",
+    "list_molecule_formats",
+    "list_structure_formats",
+    "register_molecule_format",
+    "register_structure_format",
+    "unregister_molecule_format",
+    "unregister_structure_format",
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _IOFormat:
+    """Common base for `StructureFormat` and `MoleculeFormat`.
+
+    A handler describes how a single I/O format reads and writes its target
+    object. All callables receive the user's `**kwargs` after the registry has
+    optionally filtered them against the callable's own signature (see
+    `filter_kwargs`); plugins typically take `**kwargs` and forward to the
+    underlying parser they wrap.
+
+    Attributes:
+        name: Lowercase format identifier used as the `fmt` argument.
+        patterns: Filename glob patterns used to infer the format when only a
+            filename is given. Matching is case-insensitive against the
+            basename when `case_insensitive` is True.
+        read_str: `(input_string, **kwargs) -> Structure/Molecule`. Optional;
+            if absent, the format can only be read from a file.
+        read_file: `(filename, **kwargs) -> Structure/Molecule`. Optional; if
+            absent, the registry reads the file as text and delegates to
+            `read_str`.
+        write_str: `(obj, **kwargs) -> str`. Optional; if absent, the format
+            cannot be serialized to a string and `write_file` must be present.
+        write_file: `(obj, filename, **kwargs) -> None`. Optional; if absent,
+            the registry writes `write_str(obj, **kwargs)` to the filename.
+        binary: Set True for binary-only formats (e.g. NetCDF). Disables the
+            text-mode fallback that delegates `read_file` → `read_str`.
+        case_insensitive: If True (the default), filename glob matching uses
+            the lowercased basename.
+    """
+
+    name: str
+    patterns: tuple[str, ...] = ()
+    read_str: Callable[..., object] | None = None
+    read_file: Callable[..., object] | None = None
+    write_str: Callable[..., str] | None = None
+    write_file: Callable[..., None] | None = None
+    binary: bool = False
+    case_insensitive: bool = True
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StructureFormat(_IOFormat):
+    """Plugin descriptor for a `Structure` (periodic) I/O format."""
+
+
+@dataclass(frozen=True)
+class MoleculeFormat(_IOFormat):
+    """Plugin descriptor for a `Molecule` (non-periodic) I/O format."""
+
+
+# ---------------------------------------------------------------------------
+# Built-in module map and pattern priority
+# ---------------------------------------------------------------------------
+
+# Format name -> dotted module path. The module's import triggers registration
+# of its format(s) as a side effect. This is just the discovery layer; the
+# canonical handler lives in the imported module.
+_BUILTIN_STRUCTURE_MODULES: dict[str, str] = {
+    "cif": "pymatgen.io.cif",
+    "mcif": "pymatgen.io.cif",
+    "poscar": "pymatgen.io.vasp",
+    "chgcar": "pymatgen.io.vasp",
+    "locpot": "pymatgen.io.vasp",
+    "vasprun": "pymatgen.io.vasp",
+    "cssr": "pymatgen.io.cssr",
+    "xsf": "pymatgen.io.xcrysden",
+    "mcsqs": "pymatgen.io.atat",
+    "prismatic": "pymatgen.io.prismatic",
+    "res": "pymatgen.io.res",
+    "pwmat": "pymatgen.io.pwmat",
+    "exciting": "pymatgen.io.exciting.inputs",
+    "lmto": "pymatgen.io.lmto",
+    "abinit-nc": "pymatgen.io.abinit.netcdf",
+    # External namespace packages — their pymatgen.io.<name> modules register
+    # themselves if installed. We list them here so the lookup triggers the
+    # import; if not installed, ImportError surfaces to the caller.
+    "aims": "pymatgen.io.aims.inputs",
+    "fleur": "pymatgen.io.fleur",
+    "fleur-inpgen": "pymatgen.io.fleur",
+}
+
+_BUILTIN_MOLECULE_MODULES: dict[str, str] = {
+    "xyz": "pymatgen.io.xyz",
+    "gaussian": "pymatgen.io.gaussian",
+    "gaussian-out": "pymatgen.io.gaussian",
+    # Common short-form aliases registered by pymatgen.io.gaussian.
+    "gjf": "pymatgen.io.gaussian",
+    "g03": "pymatgen.io.gaussian",
+    "g09": "pymatgen.io.gaussian",
+    "com": "pymatgen.io.gaussian",
+    "inp": "pymatgen.io.gaussian",
+    "babel": "pymatgen.io.babel",
+    # Babel-supported molecule formats.
+    "pdb": "pymatgen.io.babel",
+    "mol": "pymatgen.io.babel",
+    "mdl": "pymatgen.io.babel",
+    "sdf": "pymatgen.io.babel",
+    "sd": "pymatgen.io.babel",
+    "ml2": "pymatgen.io.babel",
+    "sy2": "pymatgen.io.babel",
+    "mol2": "pymatgen.io.babel",
+    "cml": "pymatgen.io.babel",
+    "mrv": "pymatgen.io.babel",
+}
+
+# Ordered (format_name, glob) pairs used when only a filename is given. Order
+# preserves the resolution priority of the legacy if/elif chain — earlier
+# entries win.
+_BUILTIN_STRUCTURE_FILENAME_PRIORITY: tuple[tuple[str, str], ...] = (
+    ("cif", "*.cif*"),
+    ("cif", "*.mcif*"),
+    ("poscar", "*POSCAR*"),
+    ("poscar", "*CONTCAR*"),
+    ("poscar", "*.vasp"),
+    ("chgcar", "CHGCAR*"),
+    ("chgcar", "LOCPOT*"),
+    ("vasprun", "vasprun*.xml*"),
+    ("cssr", "*.cssr*"),
+    ("json", "*.json*"),
+    ("json", "*.mson*"),
+    ("yaml", "*.yaml*"),
+    ("yaml", "*.yml*"),
+    ("xsf", "*.xsf*"),
+    ("exciting", "input*.xml"),
+    ("mcsqs", "*rndstr.in*"),
+    ("mcsqs", "*lat.in*"),
+    ("mcsqs", "*bestsqs*"),
+    ("lmto", "CTRL*"),
+    ("aims", "geometry.in*"),
+    # Fleur's "*.in*" is intentionally generic and listed last so that the
+    # narrower aims / mcsqs patterns get first dibs.
+    ("fleur-inpgen", "inp*.xml"),
+    ("fleur-inpgen", "*.in*"),
+    ("fleur-inpgen", "inp_*"),
+    ("res", "*.res"),
+    ("pwmat", "*.config*"),
+    ("pwmat", "*.pwmat*"),
+    ("abinit-nc", "*.nc"),
+    # For `to`: "prismatic" is dispatched by fmt= today and would match here
+    # only if a user names their file with "prismatic" in it.
+    ("prismatic", "*prismatic*"),
+    ("aims", "geometry.in"),
+)
+
+_BUILTIN_MOLECULE_FILENAME_PRIORITY: tuple[tuple[str, str], ...] = (
+    ("xyz", "*.xyz*"),
+    ("gaussian", "*.gjf*"),
+    ("gaussian", "*.g03*"),
+    ("gaussian", "*.g09*"),
+    ("gaussian", "*.com*"),
+    ("gaussian", "*.inp*"),
+    ("gaussian-out", "*.out*"),
+    ("gaussian-out", "*.lis*"),
+    ("gaussian-out", "*.log*"),
+    ("json", "*.json*"),
+    ("json", "*.mson*"),
+    ("yaml", "*.yaml*"),
+    ("yaml", "*.yml*"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry state
+# ---------------------------------------------------------------------------
+
+_STRUCTURE_REGISTRY: dict[str, StructureFormat] = {}
+_MOLECULE_REGISTRY: dict[str, MoleculeFormat] = {}
+_LOADED_ENTRY_POINT_GROUPS: set[str] = set()
+
+
+def register_structure_format(fmt: StructureFormat) -> None:
+    """Register a `StructureFormat` handler.
+
+    Re-registering an existing name silently replaces the previous handler.
+    """
+    _STRUCTURE_REGISTRY[fmt.name.lower()] = fmt
+
+
+def register_molecule_format(fmt: MoleculeFormat) -> None:
+    """Register a `MoleculeFormat` handler."""
+    _MOLECULE_REGISTRY[fmt.name.lower()] = fmt
+
+
+def unregister_structure_format(name: str) -> None:
+    """Remove a `StructureFormat` handler. No-op if not registered."""
+    _STRUCTURE_REGISTRY.pop(name.lower(), None)
+
+
+def unregister_molecule_format(name: str) -> None:
+    """Remove a `MoleculeFormat` handler. No-op if not registered."""
+    _MOLECULE_REGISTRY.pop(name.lower(), None)
+
+
+def list_structure_formats() -> list[StructureFormat]:
+    """Return all currently registered structure formats (does not trigger lazy imports)."""
+    return list(_STRUCTURE_REGISTRY.values())
+
+
+def list_molecule_formats() -> list[MoleculeFormat]:
+    """Return all currently registered molecule formats (does not trigger lazy imports)."""
+    return list(_MOLECULE_REGISTRY.values())
+
+
+# ---------------------------------------------------------------------------
+# kwargs filtering
+# ---------------------------------------------------------------------------
+
+
+def filter_kwargs(func: Callable, kwargs: dict, *, stacklevel: int = 3) -> dict:
+    """Filter `kwargs` to those accepted by `func`, warning about any dropped.
+
+    Mirrors the legacy `IStructure._filter_kwargs` behavior:
+    - Functions that declare `**kwargs` get the full dict unchanged.
+    - Otherwise only keys whose names match the function's parameters are
+      kept; the rest are dropped with a `UserWarning`.
+
+    Plugin authors typically call this inside their adapter to forward only
+    the relevant kwargs to the underlying parser class, e.g.::
+
+        def _cif_read_str(s, *, primitive=False, **kwargs):
+            kwargs = filter_kwargs(CifParser.from_str, kwargs)
+            return CifParser.from_str(s, **kwargs).parse_structures(primitive=primitive)[0]
+    """
+    params = inspect.signature(func).parameters
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return kwargs
+    supported = {k: v for k, v in kwargs.items() if k in params}
+    unsupported = kwargs.keys() - supported.keys()
+    if unsupported:
+        warnings.warn(
+            f"The following kwargs are not supported by {func.__qualname__} and will be ignored: {unsupported}",
+            stacklevel=stacklevel,
+        )
+    return supported
+
+
+# ---------------------------------------------------------------------------
+# Lookup
+# ---------------------------------------------------------------------------
+
+
+def _ensure_loaded_structure(name: str) -> None:
+    name = name.lower()
+    if name in _STRUCTURE_REGISTRY:
+        return
+    module = _BUILTIN_STRUCTURE_MODULES.get(name)
+    if module:
+        importlib.import_module(module)
+        return
+    _load_entry_points("pymatgen.io.structure_formats")
+
+
+def _ensure_loaded_molecule(name: str) -> None:
+    name = name.lower()
+    if name in _MOLECULE_REGISTRY:
+        return
+    module = _BUILTIN_MOLECULE_MODULES.get(name)
+    if module:
+        importlib.import_module(module)
+        return
+    _load_entry_points("pymatgen.io.molecule_formats")
+
+
+def _load_entry_points(group: str) -> None:
+    """Import every entry-point in `group` once. Cached by group name."""
+    if group in _LOADED_ENTRY_POINT_GROUPS:
+        return
+    _LOADED_ENTRY_POINT_GROUPS.add(group)
+    try:
+        from importlib.metadata import entry_points
+
+        for ep in entry_points(group=group):
+            # The convention is that the entry-point value points at a module
+            # whose import side-effect registers the format(s).
+            try:
+                importlib.import_module(ep.value)
+            except ImportError as exc:
+                warnings.warn(
+                    f"Failed to load pymatgen I/O plugin {ep.name!r} from {ep.value!r}: {exc}",
+                    stacklevel=2,
+                )
+    except Exception as exc:  # pragma: no cover — defensive
+        warnings.warn(f"Entry-point discovery for {group!r} failed: {exc}", stacklevel=2)
+
+
+def _match_filename(filename: str, pattern: str, *, case_insensitive: bool) -> bool:
+    fname = os.path.basename(filename)
+    if case_insensitive:
+        return fnmatch(fname.lower(), pattern.lower())
+    return fnmatch(fname, pattern)
+
+
+_BUILTIN_STRUCTURE_NAMES = frozenset(name for name, _ in _BUILTIN_STRUCTURE_FILENAME_PRIORITY)
+_BUILTIN_MOLECULE_NAMES = frozenset(name for name, _ in _BUILTIN_MOLECULE_FILENAME_PRIORITY)
+
+
+def _resolve_structure_by_filename(filename: str) -> str | None:
+    """Return the format name that matches the filename, or None.
+
+    Resolution order:
+
+    1. The ordered `_BUILTIN_STRUCTURE_FILENAME_PRIORITY` list (preserves the
+       priority of the legacy if/elif chain).
+    2. Patterns declared by additionally-registered handlers — i.e. plugins
+       whose format name is *not* a built-in. Built-in names still go through
+       the priority list above, so a plugin registering `name="cif"` overrides
+       the built-in CIF read/write code but doesn't change pattern priority.
+    """
+    for name, pat in _BUILTIN_STRUCTURE_FILENAME_PRIORITY:
+        if _match_filename(filename, pat, case_insensitive=True):
+            return name
+    for fmt in _STRUCTURE_REGISTRY.values():
+        if fmt.name in _BUILTIN_STRUCTURE_NAMES:
+            continue
+        for pat in fmt.patterns:
+            if _match_filename(filename, pat, case_insensitive=fmt.case_insensitive):
+                return fmt.name
+    return None
+
+
+def _resolve_molecule_by_filename(filename: str) -> str | None:
+    for name, pat in _BUILTIN_MOLECULE_FILENAME_PRIORITY:
+        if _match_filename(filename, pat, case_insensitive=True):
+            return name
+    for fmt in _MOLECULE_REGISTRY.values():
+        if fmt.name in _BUILTIN_MOLECULE_NAMES:
+            continue
+        for pat in fmt.patterns:
+            if _match_filename(filename, pat, case_insensitive=fmt.case_insensitive):
+                return fmt.name
+    return None
+
+
+def get_structure_format(*, name: str = "", filename: str = "") -> StructureFormat:
+    """Resolve a `StructureFormat` handler by explicit name or filename.
+
+    Args:
+        name: Format identifier (case-insensitive). Takes precedence over
+            `filename` when both are given.
+        filename: Path or filename used to infer the format from its glob.
+
+    Raises:
+        ValueError: If neither argument resolves to a known format. The error
+            message mirrors the legacy `Structure.from_file`/`to` wording so
+            existing user-facing assertions keep passing.
+    """
+    name = (name or "").lower()
+    filename = filename or ""
+
+    if name:
+        _ensure_loaded_structure(name)
+        if name in _STRUCTURE_REGISTRY:
+            return _STRUCTURE_REGISTRY[name]
+        if filename:
+            raise ValueError(f"Invalid fmt={name!r}")
+        raise ValueError(f"Invalid fmt={name!r}")
+
+    if not filename:
+        raise ValueError("Either fmt or filename must be provided.")
+
+    resolved = _resolve_structure_by_filename(filename)
+    if resolved is None:
+        # Try entry-points once before giving up.
+        _load_entry_points("pymatgen.io.structure_formats")
+        resolved = _resolve_structure_by_filename(filename)
+
+    if resolved is None:
+        raise ValueError(f"Unrecognized extension in filename={filename!r}")
+
+    _ensure_loaded_structure(resolved)
+    if resolved in _STRUCTURE_REGISTRY:
+        return _STRUCTURE_REGISTRY[resolved]
+
+    raise ValueError(f"Unrecognized extension in filename={filename!r}")
+
+
+def get_molecule_format(*, name: str = "", filename: str = "") -> MoleculeFormat:
+    """Resolve a `MoleculeFormat` handler by explicit name or filename."""
+    name = (name or "").lower()
+    filename = filename or ""
+
+    if name:
+        _ensure_loaded_molecule(name)
+        if name in _MOLECULE_REGISTRY:
+            return _MOLECULE_REGISTRY[name]
+        raise ValueError(f"Invalid fmt={name!r}")
+
+    if not filename:
+        raise ValueError("Either fmt or filename must be provided.")
+
+    resolved = _resolve_molecule_by_filename(filename)
+    if resolved is None:
+        _load_entry_points("pymatgen.io.molecule_formats")
+        resolved = _resolve_molecule_by_filename(filename)
+
+    if resolved is None:
+        raise ValueError("Cannot determine file type.")
+
+    _ensure_loaded_molecule(resolved)
+    if resolved in _MOLECULE_REGISTRY:
+        return _MOLECULE_REGISTRY[resolved]
+
+    raise ValueError("Cannot determine file type.")
+
+
+# ---------------------------------------------------------------------------
+# High-level dispatch helpers
+# ---------------------------------------------------------------------------
+
+
+def dispatch_read_str(handler: _IOFormat, input_string: str, /, **kwargs):
+    """Read an object from a string via `handler`.
+
+    The return type is `IStructure | Molecule` in practice, depending on
+    whether `handler` is a `StructureFormat` or `MoleculeFormat`. Typed as
+    `Any` so callers don't need format-aware narrowing.
+    """
+    if handler.read_str is None:
+        raise ValueError(f"Format {handler.name!r} cannot be read from a string.")
+    return handler.read_str(input_string, **kwargs)
+
+
+def dispatch_read_file(handler: _IOFormat, filename: str, /, **kwargs):
+    """Read an object from a file via `handler`."""
+    if handler.read_file is not None:
+        return handler.read_file(filename, **kwargs)
+    if handler.read_str is None or handler.binary:
+        raise ValueError(f"Format {handler.name!r} cannot be read from a file.")
+    with zopen(filename, mode="rt", errors="replace", encoding="utf-8") as file:
+        contents = file.read()
+    return handler.read_str(contents, **kwargs)
+
+
+def dispatch_write(handler: _IOFormat, obj: object, filename: str = "", /, **kwargs) -> str | None:
+    """Write `obj` via `handler`; returns the string representation when available."""
+    out_str: str | None = None
+    if handler.write_str is not None:
+        out_str = handler.write_str(obj, **kwargs)
+    if filename:
+        if handler.write_file is not None:
+            handler.write_file(obj, filename, **kwargs)
+        elif out_str is not None:
+            mode = "wb" if handler.binary else "wt"
+            encoding = None if handler.binary else "utf-8"
+            with zopen(filename, mode=mode, encoding=encoding) as file:
+                file.write(out_str if not handler.binary else out_str.encode())  # type:ignore[arg-type]
+        else:
+            raise ValueError(f"Format {handler.name!r} cannot be written.")
+    return out_str
+
+
+# ---------------------------------------------------------------------------
+# Built-in JSON / YAML handlers (no separate io module)
+# ---------------------------------------------------------------------------
+
+
+def _structure_from_dict(dct: dict) -> IStructure:
+    from pymatgen.core.structure import Structure
+
+    return Structure.from_dict(dct)
+
+
+def _molecule_from_dict(dct: dict) -> IMolecule:
+    from pymatgen.core.structure import Molecule
+
+    return Molecule.from_dict(dct)
+
+
+def _json_read_struct(s: str, **kwargs) -> IStructure:
+    import orjson
+
+    return _structure_from_dict(orjson.loads(s))
+
+
+def _json_read_mol(s: str, **kwargs) -> IMolecule:
+    import orjson
+
+    return _molecule_from_dict(orjson.loads(s))
+
+
+def _json_write(obj: object, **kwargs) -> str:
+    import json as _json
+
+    import orjson
+
+    as_dict = obj.as_dict()  # type:ignore[attr-defined]
+    if kwargs:
+        return _json.dumps(as_dict, **kwargs)
+    return orjson.dumps(as_dict, option=orjson.OPT_SERIALIZE_NUMPY).decode()
+
+
+def _yaml_read_struct(s: str, **kwargs) -> IStructure:
+    from ruamel.yaml import YAML
+
+    return _structure_from_dict(YAML().load(s))
+
+
+def _yaml_read_mol(s: str, **kwargs) -> IMolecule:
+    from ruamel.yaml import YAML
+
+    return _molecule_from_dict(YAML().load(s))
+
+
+def _yaml_write(obj: object, **kwargs) -> str:
+    import io as _io
+
+    from ruamel.yaml import YAML
+
+    buf = _io.StringIO()
+    YAML().dump(obj.as_dict(), buf)  # type:ignore[attr-defined]
+    return buf.getvalue()
+
+
+def _register_builtin_json_yaml() -> None:
+    register_structure_format(
+        StructureFormat(
+            name="json",
+            patterns=("*.json*", "*.mson*"),
+            read_str=_json_read_struct,
+            write_str=_json_write,
+        )
+    )
+    register_structure_format(
+        StructureFormat(
+            name="yaml",
+            patterns=("*.yaml*", "*.yml*"),
+            read_str=_yaml_read_struct,
+            write_str=_yaml_write,
+        )
+    )
+    # "yml" is a common alias for yaml.
+    register_structure_format(
+        StructureFormat(
+            name="yml",
+            patterns=(),
+            read_str=_yaml_read_struct,
+            write_str=_yaml_write,
+        )
+    )
+    register_molecule_format(
+        MoleculeFormat(
+            name="json",
+            patterns=("*.json*", "*.mson*"),
+            read_str=_json_read_mol,
+            write_str=_json_write,
+        )
+    )
+    register_molecule_format(
+        MoleculeFormat(
+            name="yaml",
+            patterns=("*.yaml*", "*.yml*"),
+            read_str=_yaml_read_mol,
+            write_str=_yaml_write,
+        )
+    )
+    register_molecule_format(
+        MoleculeFormat(
+            name="yml",
+            patterns=(),
+            read_str=_yaml_read_mol,
+            write_str=_yaml_write,
+        )
+    )
+
+
+_register_builtin_json_yaml()
+
+
+# ---------------------------------------------------------------------------
+# Compatibility shims for external namespace packages
+# ---------------------------------------------------------------------------
+#
+# `pymatgen-io-fleur` and `pymatgen-io-aims` live outside pymatgen-core. Until
+# those packages publish their own `register_structure_format(...)` calls,
+# these shims preserve the behavior of the legacy if/elif dispatch in
+# `core/structure.py` for users who have either package installed.
+
+
+def _aims_read_str(input_string: str, **kwargs):
+    from pymatgen.io.aims.inputs import AimsGeometryIn
+
+    kwargs.pop("primitive", None)
+    return AimsGeometryIn.from_str(input_string, **filter_kwargs(AimsGeometryIn.from_str, kwargs)).structure
+
+
+def _aims_write_str(structure, **kwargs) -> str:
+    from pymatgen.io.aims.inputs import AimsGeometryIn
+
+    return AimsGeometryIn.from_structure(structure).content
+
+
+def _aims_write_file(structure, filename, **kwargs) -> None:
+    from pymatgen.io.aims.inputs import AimsGeometryIn
+
+    geom_in = AimsGeometryIn.from_structure(structure)
+    with zopen(filename, mode="wt", encoding="utf-8") as file:
+        file.write(geom_in.get_header(filename))  # type:ignore[arg-type]
+        file.write(geom_in.content)  # type:ignore[arg-type]
+        file.write("\n")  # type:ignore[arg-type]
+
+
+def _fleur_read_str(input_string: str, *, inpgen_input: bool = True, **kwargs):
+    from pymatgen.io.fleur import FleurInput
+
+    kwargs.pop("primitive", None)
+    if kwargs:
+        warnings.warn(
+            f"kwargs {set(kwargs)} cannot be validated for fleur and will be passed through as-is.",
+            stacklevel=2,
+        )
+    return FleurInput.from_string(input_string, inpgen_input=inpgen_input, **kwargs).structure
+
+
+def _fleur_read_file(filename: str, **kwargs):
+    from pymatgen.io.fleur import FleurInput
+
+    kwargs.pop("primitive", None)
+    return FleurInput.from_file(filename, **kwargs).structure
+
+
+def _fleur_inpgen_write_str(structure, **kwargs) -> str:
+    from pymatgen.io.fleur import FleurInput
+
+    return str(FleurInput(structure, **kwargs))
+
+
+def _fleur_inpgen_write_file(structure, filename, **kwargs) -> None:
+    from pymatgen.io.fleur import FleurInput
+
+    FleurInput(structure, **kwargs).write_file(filename)
+
+
+def _try_register_external_shims() -> None:
+    """Register fall-back handlers for formats that live in external namespace pkgs.
+
+    These shims only become reachable when the user actually invokes them
+    (the underlying `from pymatgen.io.aims.inputs import ...` happens inside
+    the adapter), so they cost nothing for users without the optional pkg.
+    Once the external package publishes its own registration, that takes
+    precedence at import time.
+    """
+    register_structure_format(
+        StructureFormat(
+            name="aims",
+            patterns=("geometry.in", "geometry.in*"),
+            read_str=_aims_read_str,
+            write_str=_aims_write_str,
+            write_file=_aims_write_file,
+        )
+    )
+    register_structure_format(
+        StructureFormat(
+            name="fleur-inpgen",
+            patterns=("inp*.xml", "*.in*", "inp_*"),
+            read_str=lambda s, **kw: _fleur_read_str(s, inpgen_input=True, **kw),
+            read_file=_fleur_read_file,
+            write_str=_fleur_inpgen_write_str,
+            write_file=_fleur_inpgen_write_file,
+        )
+    )
+    register_structure_format(
+        StructureFormat(
+            name="fleur",
+            patterns=(),
+            read_str=lambda s, **kw: _fleur_read_str(s, inpgen_input=False, **kw),
+            read_file=_fleur_read_file,
+        )
+    )
+
+
+_try_register_external_shims()

--- a/src/pymatgen/io/res.py
+++ b/src/pymatgen/io/res.py
@@ -674,3 +674,48 @@ class ResIO:
     def entry_to_file(cls, entry: ComputedStructureEntry, filename: str) -> None:
         """Write a pymatgen ComputedStructureEntry to a res file."""
         return ResWriter(entry).write(filename)
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <-> AIRSS res
+# ----------------------------------------------------------------------------
+
+
+def _res_read_str(input_string: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return ResIO.structure_from_str(input_string, **filter_kwargs(ResIO.structure_from_str, kwargs))
+
+
+def _res_read_file(filename: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return ResIO.structure_from_file(filename, **filter_kwargs(ResIO.structure_from_file, kwargs))
+
+
+def _res_write_str(structure, **kwargs) -> str:
+    return ResIO.structure_to_str(structure)
+
+
+def _res_write_file(structure, filename, **kwargs) -> None:
+    ResIO.structure_to_file(structure, filename)
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="res",
+            patterns=("*.res",),
+            read_str=_res_read_str,
+            read_file=_res_read_file,
+            write_str=_res_write_str,
+            write_file=_res_write_file,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/vasp/__init__.py
+++ b/src/pymatgen/io/vasp/__init__.py
@@ -25,3 +25,80 @@ from .outputs import (
     Waveder,
     Xdatcar,
 )
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <-> POSCAR / CHGCAR / vasprun
+# ----------------------------------------------------------------------------
+
+
+def _poscar_read_str(input_string: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)  # not honored by POSCAR
+    return Poscar.from_str(
+        input_string,
+        default_names=None,
+        read_velocities=False,
+        **filter_kwargs(Poscar.from_str, kwargs),
+    ).structure
+
+
+def _poscar_write_str(structure, **kwargs) -> str:
+    return str(Poscar(structure, **kwargs))
+
+
+def _poscar_write_file(structure, filename, **kwargs) -> None:
+    Poscar(structure, **kwargs).write_file(filename)
+
+
+def _chgcar_read_file(filename: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return Chgcar.from_file(filename, **filter_kwargs(Chgcar.from_file, kwargs)).structure
+
+
+def _vasprun_read_file(filename: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    return Vasprun(filename, **filter_kwargs(Vasprun.__init__, kwargs)).final_structure
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="poscar",
+            patterns=("*POSCAR*", "*CONTCAR*", "*.vasp"),
+            read_str=_poscar_read_str,
+            write_str=_poscar_write_str,
+            write_file=_poscar_write_file,
+        )
+    )
+    register_structure_format(
+        StructureFormat(
+            name="chgcar",
+            patterns=("CHGCAR*", "LOCPOT*"),
+            read_file=_chgcar_read_file,
+        )
+    )
+    # Alias "locpot" -> same handler (file pattern is the discriminator).
+    register_structure_format(
+        StructureFormat(
+            name="locpot",
+            patterns=("LOCPOT*",),
+            read_file=_chgcar_read_file,
+        )
+    )
+    register_structure_format(
+        StructureFormat(
+            name="vasprun",
+            patterns=("vasprun*.xml*",),
+            read_file=_vasprun_read_file,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/xcrysden.py
+++ b/src/pymatgen/io/xcrysden.py
@@ -861,3 +861,67 @@ class AnimatedXSF:
     def as_trajectory(self) -> Trajectory:
         """Convert periodic AXSF frames to a pymatgen trajectory."""
         raise NotImplementedError("Conversion from AnimatedXSF to Trajectory is not implemented yet")
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Structure <-> XSF
+# ----------------------------------------------------------------------------
+
+
+def _xsf_read_str(input_string: str, **kwargs):
+    from pymatgen.core.structure import Molecule as _Molecule
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    xsf = XSF.from_str(input_string, **filter_kwargs(XSF.from_str, kwargs))
+    if xsf.structure is None:
+        raise ValueError("XSF data does not contain a structure; use XSF.from_str for grids or band data")
+    if isinstance(xsf.structure, _Molecule):
+        # Preserve legacy ValueError (see Structure.from_str pre-refactor).
+        raise ValueError("XSF data contains a Molecule; use pymatgen.io.xcrysden.XSF for molecular data")  # noqa: TRY004
+    struct = xsf.structure
+    struct.properties.update(xsf.structure_properties())
+    return struct
+
+
+def _xsf_read_file(filename: str, **kwargs):
+    from pymatgen.core.structure import Molecule as _Molecule
+    from pymatgen.io.registry import filter_kwargs
+
+    kwargs.pop("primitive", None)
+    with zopen(filename, mode="rb") as file:
+        xsf = XSF.parse_file(file, **filter_kwargs(XSF.parse_file, kwargs))
+    if xsf.structure is None:
+        raise ValueError("XSF data does not contain a structure; use XSF.from_file for grids or band data")
+    if isinstance(xsf.structure, _Molecule):
+        # Preserve legacy ValueError (see Structure.from_str pre-refactor).
+        raise ValueError("XSF data contains a Molecule; use pymatgen.io.xcrysden.XSF for molecular data")  # noqa: TRY004
+    struct = xsf.structure
+    struct.properties.update(xsf.structure_properties())
+    return struct
+
+
+def _xsf_write_str(structure, **kwargs) -> str:
+    return XSF(structure).to_str(**kwargs)
+
+
+def _xsf_write_file(structure, filename, **kwargs) -> None:
+    XSF(structure).write_file(filename, **kwargs)
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import StructureFormat, register_structure_format
+
+    register_structure_format(
+        StructureFormat(
+            name="xsf",
+            patterns=("*.xsf*",),
+            read_str=_xsf_read_str,
+            read_file=_xsf_read_file,
+            write_str=_xsf_write_str,
+            write_file=_xsf_write_file,
+        )
+    )
+
+
+_register_formats()

--- a/src/pymatgen/io/xyz.py
+++ b/src/pymatgen/io/xyz.py
@@ -152,3 +152,39 @@ class XYZ:
         """
         with zopen(filename, mode="wt", encoding="utf-8") as file:
             file.write(str(self))  # type:ignore[arg-type]
+
+
+# ----------------------------------------------------------------------------
+# pymatgen.io.registry plugin: Molecule <-> XYZ
+# ----------------------------------------------------------------------------
+
+
+def _xyz_read_str(input_string: str, **kwargs):
+    from pymatgen.io.registry import filter_kwargs
+
+    return XYZ.from_str(input_string, **filter_kwargs(XYZ.from_str, kwargs)).molecule
+
+
+def _xyz_write_str(molecule, **kwargs) -> str:
+    return str(XYZ(molecule, **kwargs))
+
+
+def _xyz_write_file(molecule, filename, **kwargs) -> None:
+    XYZ(molecule, **kwargs).write_file(filename)
+
+
+def _register_formats() -> None:
+    from pymatgen.io.registry import MoleculeFormat, register_molecule_format
+
+    register_molecule_format(
+        MoleculeFormat(
+            name="xyz",
+            patterns=("*.xyz*",),
+            read_str=_xyz_read_str,
+            write_str=_xyz_write_str,
+            write_file=_xyz_write_file,
+        )
+    )
+
+
+_register_formats()

--- a/tests/io/test_registry.py
+++ b/tests/io/test_registry.py
@@ -142,14 +142,18 @@ class TestErrorMessages:
 
 class TestFilterKwargs:
     def test_filters_unsupported(self):
-        def f(a, b=1): ...  # signature has only a, b
+        # Signature has only a, b — `bogus` should be dropped with a warning.
+        def f(a, b=1):
+            pass
 
         with pytest.warns(UserWarning, match="bogus"):
             filtered = filter_kwargs(f, {"a": 1, "bogus": 2})
         assert filtered == {"a": 1}
 
     def test_passes_through_with_var_keyword(self):
-        def f(**kwargs): ...
+        # `**kwargs` opt-out: nothing should be filtered or warned about.
+        def f(**kwargs):
+            pass
 
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)

--- a/tests/io/test_registry.py
+++ b/tests/io/test_registry.py
@@ -1,0 +1,207 @@
+"""Tests for the plugin registry that backs `Structure`/`Molecule` I/O dispatch."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from pymatgen.core import Lattice, Molecule, Structure
+from pymatgen.io.registry import (
+    StructureFormat,
+    filter_kwargs,
+    get_molecule_format,
+    get_structure_format,
+    list_structure_formats,
+    register_structure_format,
+    unregister_structure_format,
+)
+
+
+@pytest.fixture
+def simple_structure():
+    return Structure(Lattice.cubic(3), ["Si", "Si"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+
+
+@pytest.fixture
+def simple_molecule():
+    return Molecule(["C", "O"], [[0, 0, 0], [1.1, 0, 0]])
+
+
+class TestRegistration:
+    def test_register_and_get(self):
+        marker: list = []
+
+        def _read(s, **_):
+            marker.append(("read_str", s))
+            return Structure(Lattice.cubic(3), ["Si"], [[0, 0, 0]])
+
+        fmt = StructureFormat(name="testfmt-roundtrip", patterns=("*.testfmt",), read_str=_read)
+        try:
+            register_structure_format(fmt)
+            assert get_structure_format(name="testfmt-roundtrip") is fmt
+            assert get_structure_format(filename="x.testfmt") is fmt
+        finally:
+            unregister_structure_format("testfmt-roundtrip")
+
+    def test_unregister(self):
+        fmt = StructureFormat(name="testfmt-unreg", patterns=("*.unreg",))
+        register_structure_format(fmt)
+        assert any(f.name == "testfmt-unreg" for f in list_structure_formats())
+        unregister_structure_format("testfmt-unreg")
+        assert not any(f.name == "testfmt-unreg" for f in list_structure_formats())
+        # Unregistering twice is a no-op.
+        unregister_structure_format("testfmt-unreg")
+
+    def test_register_case_insensitive_name(self):
+        fmt = StructureFormat(name="TestUpperCase", patterns=())
+        try:
+            register_structure_format(fmt)
+            # Lookup is case-insensitive on the name.
+            assert get_structure_format(name="testuppercase") is fmt
+            assert get_structure_format(name="TESTUPPERCASE") is fmt
+        finally:
+            unregister_structure_format("TestUpperCase")
+
+
+class TestBuiltinDispatch:
+    """Built-in formats should resolve via the lazy-import map (no manual registration)."""
+
+    @pytest.mark.parametrize("fmt", ["cif", "poscar", "cssr", "xsf", "res", "pwmat", "json", "yaml"])
+    def test_structure_fmt_lookup(self, fmt):
+        handler = get_structure_format(name=fmt)
+        assert handler.name == fmt
+
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("foo.cif", "cif"),
+            # Legacy behavior: *.cif* glob also matches .mcif (reading mcif uses
+            # the same CIF parser; only writing distinguishes magnetic CIF).
+            ("foo.mcif", "cif"),
+            ("POSCAR", "poscar"),
+            ("CONTCAR", "poscar"),
+            ("foo.vasp", "poscar"),
+            ("CHGCAR", "chgcar"),
+            ("LOCPOT", "chgcar"),
+            ("vasprun.xml", "vasprun"),
+            ("foo.cssr", "cssr"),
+            ("foo.json", "json"),
+            ("foo.yaml", "yaml"),
+            ("foo.yml", "yaml"),
+            ("foo.xsf", "xsf"),
+            ("foo.res", "res"),
+            ("rndstr.in", "mcsqs"),
+            ("CTRL.foo", "lmto"),
+            ("foo.config", "pwmat"),
+            ("foo.pwmat", "pwmat"),
+        ],
+    )
+    def test_structure_filename_inference(self, filename, expected):
+        handler = get_structure_format(filename=filename)
+        assert handler.name == expected
+
+    @pytest.mark.parametrize("fmt", ["xyz", "gaussian", "gjf", "g09", "json", "yaml"])
+    def test_molecule_fmt_lookup(self, fmt):
+        handler = get_molecule_format(name=fmt)
+        assert handler.name == fmt
+
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("foo.xyz", "xyz"),
+            ("foo.gjf", "gaussian"),
+            ("foo.g09", "gaussian"),
+            ("foo.out", "gaussian-out"),
+            ("foo.json", "json"),
+            ("foo.yaml", "yaml"),
+        ],
+    )
+    def test_molecule_filename_inference(self, filename, expected):
+        handler = get_molecule_format(filename=filename)
+        assert handler.name == expected
+
+
+class TestErrorMessages:
+    def test_unknown_fmt(self):
+        with pytest.raises(ValueError, match="badformat"):
+            get_structure_format(name="badformat")
+
+    def test_no_args(self):
+        with pytest.raises(ValueError, match="Either fmt or filename"):
+            get_structure_format()
+
+    def test_unknown_filename(self):
+        with pytest.raises(ValueError, match="Unrecognized extension"):
+            get_structure_format(filename="whatever.unknownext")
+
+    def test_molecule_unknown_filename(self):
+        with pytest.raises(ValueError, match="Cannot determine"):
+            get_molecule_format(filename="whatever.unknownext")
+
+
+class TestFilterKwargs:
+    def test_filters_unsupported(self):
+        def f(a, b=1): ...  # signature has only a, b
+
+        with pytest.warns(UserWarning, match="bogus"):
+            filtered = filter_kwargs(f, {"a": 1, "bogus": 2})
+        assert filtered == {"a": 1}
+
+    def test_passes_through_with_var_keyword(self):
+        def f(**kwargs): ...
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = filter_kwargs(f, {"a": 1, "b": 2})
+        assert result == {"a": 1, "b": 2}
+
+
+class TestRoundtripsViaRegistry:
+    """End-to-end checks that the public `Structure`/`Molecule` API still works
+    after dispatch goes through the registry."""
+
+    @pytest.mark.parametrize("fmt", ["cif", "poscar", "cssr", "json", "yaml", "xsf", "res", "pwmat"])
+    def test_structure_roundtrip(self, fmt, simple_structure):
+        s_str = simple_structure.to(fmt=fmt)
+        assert isinstance(s_str, str)
+        assert s_str
+        s2 = Structure.from_str(s_str, fmt=fmt)
+        assert s2.formula == simple_structure.formula
+
+    @pytest.mark.parametrize("fmt", ["xyz", "gjf", "json", "yaml"])
+    def test_molecule_roundtrip(self, fmt, simple_molecule):
+        m_str = simple_molecule.to(fmt=fmt)
+        assert isinstance(m_str, str)
+        assert m_str
+        m2 = Molecule.from_str(m_str, fmt=fmt)
+        assert m2.formula == simple_molecule.formula
+
+
+class TestPluginOverride:
+    """A user-supplied plugin should be able to override a built-in format and the
+    public `Structure.from_str` dispatch should use the new handler."""
+
+    def test_user_plugin_overrides_builtin(self, simple_structure):
+        call_log: list[str] = []
+        original = get_structure_format(name="cif")
+
+        def _intercept_read_str(s, **kwargs):
+            call_log.append("intercepted")
+            return original.read_str(s, **kwargs)  # type:ignore[misc]
+
+        replacement = StructureFormat(
+            name="cif",
+            patterns=("*.cif*",),
+            read_str=_intercept_read_str,
+            write_str=original.write_str,
+            write_file=original.write_file,
+        )
+        try:
+            register_structure_format(replacement)
+            cif = simple_structure.to(fmt="cif")
+            Structure.from_str(cif, fmt="cif")
+            assert call_log == ["intercepted"]
+        finally:
+            # Reinstate the built-in handler so other tests don't see leakage.
+            register_structure_format(original)


### PR DESCRIPTION
## Summary

- Replaces the monolithic if/elif chains in `IStructure.{from_file,from_str,to}` and `IMolecule.{from_file,from_str,to}` with a plugin registry living in a new `pymatgen.io.registry` module. Each `pymatgen.io.<format>` now owns its own read/write glue and self-registers `StructureFormat`/`MoleculeFormat` handlers at module-import time.
- Built-in formats stay first-class: a static `format_name -> module_path` table lazy-imports the relevant io module on first use, so `from pymatgen.core import Structure` doesn't pay any extra import cost. External packages can plug in additional formats via the `pymatgen.io.structure_formats` and `pymatgen.io.molecule_formats` entry-point groups, or by importing a module that calls `register_structure_format(...)`.
- Existing user-facing behavior (format aliases, filename inference priority, error message wording, kwarg-warning semantics, default-to-JSON) is preserved. `IStructure._filter_kwargs` is kept as a thin shim around `pymatgen.io.registry.filter_kwargs`.
- `aims` and `fleur` (external namespace packages) get fallback shims in the registry so users with those packages installed keep working without a coordinated release.

## Plugin author API

```python
from pymatgen.io.registry import StructureFormat, register_structure_format, filter_kwargs

def _read(s, *, primitive=False, **kwargs):
    kwargs = filter_kwargs(SomeParser.from_str, kwargs)
    return SomeParser.from_str(s, **kwargs).structure

register_structure_format(StructureFormat(
    name="myfmt",
    patterns=("*.myf",),
    read_str=_read,
    write_str=lambda s, **kw: SomeWriter(s, **kw).get_str(),
    write_file=lambda s, fn, **kw: SomeWriter(s, **kw).write_file(fn),
))
```

External packages publish entry points in `pyproject.toml`:

```toml
[project.entry-points."pymatgen.io.structure_formats"]
myfmt = "my_pkg.io_module"
```

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy -p pymatgen` — 119 errors (was 120 on `main`; my change reduced by 1, no new errors in registry or refactored files)
- [x] `uv run pyright src` — 0 errors / 0 warnings
- [x] `uv run pytest tests` — **2725 passed**, 197 skipped (missing optional deps), 5 xfailed, 1 xpassed
- [x] New `tests/io/test_registry.py` (60 cases) covering registration, lookup by name and by filename, error paths, kwargs filtering, end-to-end roundtrips, and plugin-override-of-builtin
- [x] Manual smoke test: registering a custom `StructureFormat` and dispatching through the public `Structure.to/from_str/from_file` API succeeds and respects filename inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)