### PR TITLE
Fix scientific notation list parsing/writing for `INCAR` files

### DIFF
--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -1042,11 +1042,14 @@ class Incar(UserDict, MSONable):
                     return int(str_)
 
                 output = []
-                tokens = re.findall(r"(-?\d+\.?\d*|[\.A-Z]+)\*?(-?\d+\.?\d*|[\.A-Z]+)?\*?(-?\d+\.?\d*|[\.A-Z]+)?", val)
+                # a single token is a number (incl. scientific notation, e.g. 1e-3) or an uppercase/dot
+                # string (e.g. .TRUE.); up to 3 tokens may be joined by "*" multipliers (e.g. 9*0.6)
+                num_or_str = r"-?\d+\.?\d*(?:[eE][-+]?\d+)?|[\.A-Z]+"
+                tokens = re.findall(rf"({num_or_str})\*?({num_or_str})?\*?({num_or_str})?", val)
                 for tok in tokens:
-                    if tok[2] and "3" in tok[0]:
+                    if tok[2]:  # nested multiplier "count1*count2*value" (e.g. 3*3*-1)
                         output.extend([smart_int_or_float_bool(tok[2])] * int(tok[0]) * int(tok[1]))
-                    elif tok[1]:
+                    elif tok[1]:  # multiplier "count*value" (e.g. 9*0.6)
                         output.extend([smart_int_or_float_bool(tok[1])] * int(tok[0]))
                     else:
                         output.append(smart_int_or_float_bool(tok[0]))

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -658,7 +658,7 @@ class TestIncar(MatSciTest):
         assert float(incar["EDIFF"]) == approx(1e-4), "Wrong EDIFF"
         assert isinstance(incar["LORBIT"], int)
 
-    def test_lattice_constaints(self):
+    def test_lattice_constraints_and_ROPT(self):
         incar_str = """
         ALGO = Fast
 EDIFF = 0.00045000000000000004
@@ -676,9 +676,16 @@ MAGMOM = 9*0.6
 NELM = 100
 NSW = 99
 PREC = Accurate
+ROPT = 1e-3 1e-3
 SIGMA = 0.05"""
         incar = Incar.from_str(incar_str)
         assert incar["LATTICE_CONSTRAINTS"] == [False, False, True]
+        assert incar["ROPT"] == [1e-3, 1e-3]
+        assert incar["MAGMOM"] == [0.6] * 9
+        assert incar["PREC"] == "Accurate"
+
+        incar = Incar.from_str("ROPT = 2*1e-3")
+        assert incar["ROPT"] == [1e-3, 1e-3]
 
     def test_check_for_duplicate(self):
         incar_str: str = """encut = 400


### PR DESCRIPTION
From some [`ShakeNBreak`](https://shakenbreak.readthedocs.io/en/latest/) tests, I realised that the writing and parsing of `INCAR` flags with scientific notation in a list (e.g. [`ROPT`](https://vasp.at/wiki/ROPT); `1e-3 1e-3 1e-3`) failed, treating "e" as whitespace and converting it to `1 -3 1 -3 1 -3`. 

Essentially, list-type values are tokenized with a regex whose sub-pattern `-?\d+\.?\d*` does not support scientific-notation (treating "e" as whitespace). This PR extends the token regex to accept scientific notation: `-?\d+\.?\d*(?:[eE][-+]?\d+)?`.

Expanded some INCAR tests to catch this issue and test the fix.