### PR TITLE
fix: pbc not being preserved during structure transformations

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -4316,7 +4316,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         """
         if fractional:
             new_latt = np.dot(symm_op.rotation_matrix, self._lattice.matrix)
-            self._lattice = Lattice(new_latt)
+            self._lattice = Lattice(new_latt, pbc=self._lattice.pbc)
 
             def operate_site(site):
                 return PeriodicSite(
@@ -4330,7 +4330,9 @@ class Structure(IStructure, collections.abc.MutableSequence):
                 )
 
         else:
-            self._lattice = Lattice([symm_op.apply_rotation_only(row) for row in self._lattice.matrix])
+            self._lattice = Lattice(
+                [symm_op.apply_rotation_only(row) for row in self._lattice.matrix],
+                pbc=self._lattice.pbc)
 
             def operate_site(site):
                 new_cart = symm_op.operate(site.coords)

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1158,7 +1158,7 @@ class IStructure(SiteCollection, MSONable):
         scale_matrix = np.array(scaling_matrix, int)
         if scale_matrix.shape != (3, 3):
             scale_matrix = scale_matrix * np.eye(3)  # (ruff-preview) noqa: PLR6104
-        new_lattice = Lattice(np.dot(scale_matrix, self.lattice.matrix))
+        new_lattice = Lattice(np.dot(scale_matrix, self.lattice.matrix), pbc=self.lattice.pbc)
 
         frac_lattice = lattice_points_in_supercell(scale_matrix)
         cart_lattice: NDArray = new_lattice.get_cartesian_coords(frac_lattice)

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -4331,8 +4331,8 @@ class Structure(IStructure, collections.abc.MutableSequence):
 
         else:
             self._lattice = Lattice(
-                [symm_op.apply_rotation_only(row) for row in self._lattice.matrix],
-                pbc=self._lattice.pbc)
+                [symm_op.apply_rotation_only(row) for row in self._lattice.matrix], pbc=self._lattice.pbc
+            )
 
             def operate_site(site):
                 new_cart = symm_op.operate(site.coords)

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1046,6 +1046,10 @@ class TestStructure(MatSciTest):
         self.disordered = Structure.from_spacegroup("Im-3m", Lattice.cubic(3), [Composition("Fe0.5Mn0.5")], [[0, 0, 0]])
         self.labeled_structure = Structure(lattice, ["Si", "Si"], coords, labels=["Si1", "Si2"])
 
+        # 2-D slab: periodic in x,y only - used by pbc-preservation tests
+        slab_lattice = Lattice([[3, 0, 0], [0, 3, 0], [0, 0, 20]], pbc=(True, True, False))
+        self.slab = Structure(slab_lattice, ["Si"], [[0, 0, 0]])
+
     def test_calc_property(self):
         pytest.importorskip("matcalc")
         d = self.struct.calc_property("elasticity")
@@ -1463,6 +1467,16 @@ class TestStructure(MatSciTest):
         struct.apply_operation(op, fractional=False)
         assert struct.get_space_group_info() == spg_info
 
+        # pbc must survive symmetry operations
+        op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)
+        slab = self.slab.copy()
+        slab.apply_operation(op)  # Cartesian branch
+        assert slab.pbc == (True, True, False)
+
+        slab = self.slab.copy()
+        slab.apply_operation(op, fractional=True)  # fractional branch
+        assert slab.pbc == (True, True, False)
+
     def test_apply_strain(self):
         struct = self.struct
         initial_coord = struct[1].coords
@@ -1558,6 +1572,10 @@ class TestStructure(MatSciTest):
         assert struct.formula == "Si8"
         assert_allclose(struct.lattice.abc, [7.6803959, 17.5979979, 7.6803959])
 
+        # pbc must be preserved for every scaling form
+        for scaling in [(2, 2, 1), 2, [[2, 0, 0], [0, 2, 0], [0, 0, 1]]]:
+            assert (self.slab * scaling).pbc == (True, True, False)
+
     def test_make_supercell(self):
         supercell = self.struct.make_supercell([2, 1, 1])
         assert supercell.formula == "Si4"
@@ -1576,6 +1594,11 @@ class TestStructure(MatSciTest):
         supercell = self.struct.make_supercell([2.5, 1, 1], in_place=False)
         assert len(self.struct) == orig_len
         assert len(supercell) == 2 * orig_len
+
+        # pbc must be preserved for in-place make_supercell
+        slab = self.slab.copy()
+        slab.make_supercell((2, 2, 1))
+        assert slab.pbc == (True, True, False)
 
     def test_make_supercell_labeled(self):
         struct = self.labeled_structure.copy()

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -573,6 +573,12 @@ class TestIStructure(MatSciTest):
         struct = IStructure(Lattice.cubic(4.09), ["Ag"] * 4, coords)
         assert len(struct.get_primitive_structure()) == 4
 
+        # pbc must survive primitive-cell reduction
+        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
+        struct_pbc = IStructure(self.lattice_pbc, ["Si"] * 2, coords)
+        struct_pbc_prim = struct_pbc.get_primitive_structure()
+        assert struct_pbc_prim.pbc == (True, True, False)
+
     def test_primitive_cell_site_merging(self):
         lattice = Lattice.cubic(10)
         coords = [[0, 0, 0], [0, 0, 0.5], [0, 0, 0.26], [0, 0, 0.74]]


### PR DESCRIPTION
## Summary

PBCs (Periodic Boundary Conditions) set on a `Structure`'s `Lattice` is silently reset to `(True, True, True)` whenever certain structure transformations create a new `Lattice` object without forwarding the original `pbc`.  The most user-visible case is the `*`/`make_supercell` operator.

### Reproducing the bug
```python
from pymatgen.core import Lattice, Structure

# 2-D slab-like structure: non-periodic along z
a = 3
c = 20
latt = Lattice([[a, 0, 0], [0, a, 0], [0, 0, c]], pbc=(True, True, False))
s = Structure(latt, ["Si"], [[0, 0, 0]])

print(s.pbc)          # (True, True, False)  ← correct
print((s*(2,2,1)).pbc)   # (True, True, True)   ← BUG: pbc silently reset
```

### Comparison with ASE
[ASE (Atomic Simulation Environment)](https://ase-lib.org/) handles `pbc` correctly across **all** structure operations. Running the same workflow in both libraries makes the bug immediately concrete:

```python
from ase.atoms import Atoms

a = 3
c = 20
cell = [[a, 0, 0], [0, a, 0], [0, 0, c]]
pbc_flags = (True, True, False)           # slab: periodic in x,y only

ase_atoms  = Atoms("Si", positions=[[0, 0, 0]], cell=cell, pbc=pbc_flags)
print(ase_atoms.pbc)                      # (True, True, False)
print((ase_atoms * (2,2,1)).pbc)      # (True, True, False)
````

### Root Cause
The `IStructure.__mul__` creates a new `Lattice`  without passing `pbc=`, which defaults to `(True, True, True)`.

```python
# ❌ current (drops pbc)
new_lattice = Lattice(np.dot(scale_matrix, self.lattice.matrix))

# ✅ fix (forwards pbc)
new_lattice = Lattice(np.dot(scale_matrix, self.lattice.matrix), pbc=self.lattice.pbc)
```

### Diff
1. `IStructure.__mul__` and `make_supercell` via `*` operator
The primary bug. All supercell creation via `s * (2,2,1), s * 3`, or a full 3×3
scaling matrix drops `pbc`.
```diff
- new_lattice = Lattice(np.dot(scale_matrix, self.lattice.matrix))
+ new_lattice = Lattice(np.dot(scale_matrix, self.lattice.matrix), pbc=self.lattice.pbc)
```
`Structure.make_supercell` calls `__mul__` internally so it is fixed as a side-effect of this single change.

2. `Structure.apply_operation` — symmetry operations
Two branches (fractional-space and Cartesian-space) reconstruct `self._lattice`
after rotating it by a symmetry operation:

```diff
- self._lattice = Lattice(new_latt)
+ self._lattice = Lattice(new_latt, pbc=self._lattice.pbc)
```

```diff
- self._lattice = Lattice([symm_op.apply_rotation_only(row) for row in self._lattice.matrix])
+ self._lattice = Lattice([symm_op.apply_rotation_only(row) for row in self._lattice.matrix], pbc=self._lattice.pbc)
```

### Tests added (`tests/core/test_structure.py`)

- Appended to `TestIStructure.test_get_primitive_structure`

```python
def test_get_primitive_structure(self):
        ...

        # pbc must survive primitive-cell reduction
        coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
        struct_pbc = IStructure(self.lattice_pbc, ["Si"] * 2, coords)
        struct_pbc_prim = struct_pbc.get_primitive_structure()
        assert struct_pbc_prim.pbc == (True, True, False)
```

- `TestStructure.setup_method` — appended `self.slab` to `setup_method`

```python
def setup_method(self):
    ...
    # 2-D slab: periodic in x,y only — used by pbc-preservation tests
    slab_lattice = Lattice([[3, 0, 0], [0, 3, 0], [0, 0, 20]], pbc=(True, True, False))
    self.slab = Structure(slab_lattice, ["Si"], [[0, 0, 0]])
```

- Appended to `TestStructure.test_apply_operation`

```python
def test_apply_operation(self):
    ...

    # pbc must survive symmetry operations
    op = SymmOp.from_axis_angle_and_translation([0, 0, 1], 90)
    slab = self.slab.copy()
    slab.apply_operation(op)    # Cartesian branch
    assert slab.pbc == (True, True, False)

    slab = self.slab.copy()
    slab.apply_operation(op, fractional=True)   # fractional branch
    assert slab.pbc == (True, True, False)
```

- Appended to `TestStructure.test_mul`

```python
def test_mul(self):
    ...

    # pbc must be preserved for every scaling form
    for scaling in [(2, 2, 1), 2, [[2, 0, 0], [0, 2, 0], [0, 0, 1]]]:
        assert (self.slab * scaling).pbc == (True, True, False)
```

- Appended to `TestStructure.test_make_supercell`

```python
def test_make_supercell(self):
    ...

    # pbc must survive in-place make_supercell
    slab = self.slab.copy()
    slab.make_supercell((2, 2, 1))
    assert slab.pbc == (True, True, False)
```

## Checklist

- [x] `IStructure.__mul__` now correctly forwards the pbc.
- [x] `make_supercell` now correctly forwards the pbc.
- [x] `apply_operation` - Symmetry operations on a structure now preserve the pbc.  
- [x] Unit tests for every changed method.
- [x] No change to the public API signature
- [x] Backwards-compatible for the overwhelmingly common `pbc=(True,True,True)` case.

