### PR TITLE
Fix bug in get_projected_plots_dots

### DIFF
--- a/src/pymatgen/electronic_structure/plotter.py
+++ b/src/pymatgen/electronic_structure/plotter.py
@@ -1019,10 +1019,10 @@ class BSPlotterProjected(BSPlotter):
 
         for col_idx, element in enumerate(dictio):
             for row_idx in range(n_rows):
-                if n_cols == 1 and n_cols == 1:
+                if n_cols == 1 and n_rows == 1:
                     ax = axs
-                elif n_rows == 1:
-                    ax = axs[col_idx]
+                elif n_cols == 1 or n_rows == 1:
+                    ax = axs[max(row_idx, col_idx)]
                 else:
                     ax = axs[row_idx, col_idx]
 

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -213,7 +213,7 @@ class TestBSPlotterProjected:
         assert len(axes) == 2, f"{len(axes)=}"
         assert len(axes[0].get_lines()) == 4903, f"{len(axes[0].get_lines())=}"
         assert len(axes[-1].get_lines()) == 4903, f"{len(axes[-1].get_lines())=}"
-        
+
         axs = self.plotter_Cu2O.get_projected_plots_dots_patom_pmorb(
             {"Cu": ["dxy", "s", "px"], "O": ["px", "py", "pz"]},
             {"Cu": [3, 5], "O": [1]},

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -201,6 +201,19 @@ class TestBSPlotterProjected:
         assert len(axes) == 4, f"{len(axes)=}"
         assert len(axes[0].get_lines()) == 4903, f"{len(axes[0].get_lines())=}"
         assert len(axes[-1].get_lines()) == 0, f"{len(axes[-1].get_lines())=}"
+
+        # Test if a plot with a single column works
+        axes = self.plotter_Cu2O.get_projected_plots_dots({"Cu": ["d", "s"]})
+        assert len(axes) == 2, f"{len(axes)=}"
+        assert len(axes[0].get_lines()) == 4903, f"{len(axes[0].get_lines())=}"
+        assert len(axes[-1].get_lines()) == 4903, f"{len(axes[-1].get_lines())=}"
+
+        # Test if a plot with a single row works
+        axes = self.plotter_Cu2O.get_projected_plots_dots({"Cu": ["d"], "O": ["p"]})
+        assert len(axes) == 2, f"{len(axes)=}"
+        assert len(axes[0].get_lines()) == 4903, f"{len(axes[0].get_lines())=}"
+        assert len(axes[-1].get_lines()) == 4903, f"{len(axes[-1].get_lines())=}"
+        
         axs = self.plotter_Cu2O.get_projected_plots_dots_patom_pmorb(
             {"Cu": ["dxy", "s", "px"], "O": ["px", "py", "pz"]},
             {"Cu": [3, 5], "O": [1]},


### PR DESCRIPTION
## Summary

Major changes:

- feature 1: `get_projected_plots_dots` does not give a single plt.Axes object for `ax` when one element and multiple orbitals are inputted for `dictio` and single-column subplots are expected. 
<img width="518" height="24" alt="image" src="https://github.com/user-attachments/assets/c7a34105-8642-4abf-b9f6-d24024a20306" />
<img width="564" height="86" alt="image" src="https://github.com/user-attachments/assets/436b9eca-c1a5-406e-8de3-d6b5a92fc70c" />

- fix 1: Fixed typo in line 1021 where `n_cols == 1` is repeated twice 
`if n_cols == 1 and n_cols ==1` changed to `if n_cols == 1 and n_rows ==1`. 
`elif ~` changed to include the cases where n_cols == 1 or n_rows == 1

## Todos

If this is work in progress, what else needs to be done? N/A

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
