### PR TITLE
Fix bug in _get_projections_by_branches_patom_pmorb

### DIFF
--- a/src/pymatgen/electronic_structure/plotter.py
+++ b/src/pymatgen/electronic_structure/plotter.py
@@ -1366,7 +1366,7 @@ class BSPlotterProjected(BSPlotter):
                             for anum in dictpa[elt]:
                                 edict[f"{elt}{anum}"] = {}
                                 for morb in dictio[elt]:
-                                    edict[f"{elt}{anum}"][morb] = proj[Spin.up][band_idx][j][setos[morb]][anum - 1]
+                                    edict[f"{elt}{anum}"][morb] = proj[Spin.down][band_idx][j][setos[morb]][anum - 1]
                         proj_br[-1][str(Spin.down)][band_idx].append(edict)
 
         # Adjust projections for plot


### PR DESCRIPTION
## Summary

Major changes:

- feature 1: `get_projected_plots_dots_patom_pmorb` plots do not reflect the correct projections of `Spin.down` (cyan). 
For example, spin.down projection of Cr in band 835 (or 834 by index) is much smaller than spin.up in this band structure:
<img width="1073" height="137" alt="image" src="https://github.com/user-attachments/assets/6a8964d2-f181-44d3-af52-c39a99340739" />  
but their marker sizes, which should reflect the difference in projections, look almost the same in the projected plot:
<br>
<img width="439" height="500" alt="image" src="https://github.com/user-attachments/assets/594e3634-fcc3-48f5-8997-f5256c149ff4" />

- fix 1: `Spin.up` changed to `Spin.down` in line 1372 ( `_get_projections_by_branches_patom_pmorb`)
<img width="899" height="205" alt="image" src="https://github.com/user-attachments/assets/866f69d7-8804-40a5-9cd4-603c6e21a9c2" />

## Todos

If this is work in progress, what else needs to be done? N/A  

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
