### PR TITLE
Rescale magmoms when applying operations in CifParser

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # invoke ``tasks.py``, and the ``dev/`` directory of local helpers /
 # reproducers (not part of the installed package; lint debt there is out
 # of scope for the regular pre-commit pipeline).
-exclude: ^(docs|.*test_files|tasks\.py|dev/)
+exclude: ^(docs|.*test[_-]files|tasks\.py|dev/)
 
 # Install both pre-commit and commit-msg hook types when contributors run
 # ``pre-commit install`` — required for codespell's ``commit-msg`` stage
@@ -60,7 +60,9 @@ repos:
         stages: [pre-commit, commit-msg]
         exclude_types: [html]
         args: [--check-filenames]
-        exclude: ^pretrained_models/.*/model\.json$
+        # CHANGES.md quotes historical PR titles verbatim (typos included),
+        # so spell-checking it only flags text we can't meaningfully fix.
+        exclude: ^(pretrained_models/.*/model\.json|CHANGES\.md)$
 
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.19.0

--- a/src/pymatgen/io/cif.py
+++ b/src/pymatgen/io/cif.py
@@ -652,14 +652,23 @@ class CifParser:
                     coord = op.operate(tmp_coord)
                     coord = np.array([i - math.floor(i) for i in coord])
                     if isinstance(op, MagSymmOp):
-                        # Up to this point, magmoms have been defined relative
-                        # to crystal axis. Now convert to Cartesian and into
-                        # a Magmom object.
                         if lattice is None:
                             raise ValueError("Lattice cannot be None.")
-                        magmom = Magmom.from_moment_relative_to_crystal_axes(
-                            op.operate_magmom(tmp_magmom), lattice=lattice
+                        # Up to this point, magmoms have been defined by components along
+                        # unit crystal axes, while op.rotation_matrix is expressed in
+                        # crystallographic axes. Convert both the moment and the rotation
+                        # matrix to Cartesian coordinates before operating; applying the
+                        # crystallographic-axes rotation matrix to unit-axis components
+                        # directly changes the moment magnitude whenever the op mixes axes
+                        # of unequal length.
+                        magmom_cart = Magmom.from_moment_relative_to_crystal_axes(
+                            cast("tuple[float, float, float]", tmp_magmom), lattice=lattice
                         )
+                        rot_cart = lattice.matrix.T @ op.rotation_matrix @ np.linalg.inv(lattice.matrix.T)
+                        op_cart = MagSymmOp.from_rotation_and_translation_and_time_reversal(
+                            rot_cart, op.translation_vector, op.time_reversal
+                        )
+                        magmom = op_cart.operate_magmom(magmom_cart)
                     else:
                         magmom = Magmom(tmp_magmom)
 

--- a/test-files/io/cif/mcif/magnetic.example.HoAuGe.mcif
+++ b/test-files/io/cif/mcif/magnetic.example.HoAuGe.mcif
@@ -1,0 +1,135 @@
+#\#CIF_2.0
+# Created by the Bilbao Crystallographic Server
+# http://www.cryst.ehu.es
+# Date: 11/19/2017 17:07:11
+# Database entry: 1.34 HoAuGe
+# Cif-like file for the case 1.34
+
+
+data_5yOhtAoR
+_audit_creation_date            2017-11-19
+_audit_creation_method          "Bilbao Crystallographic Server"
+
+_chemical_name_systematic
+;
+;
+_chemical_name_common                    ?
+_chemical_formula_moiety                 ?
+_chemical_formula_structural             ?
+_chemical_formula_analytical             ?
+_chemical_formula_iupac                  ?
+_chemical_formula_sum                    'Ho Au Ge'
+_chemical_formula_weight                 ?
+_chemical_melting_point                  ?
+_chemical_compound_source                ?
+_chemical_absolute_configuration         .
+
+
+_citation_journal_abbrev        "Journal of Magnetism and Magnetic Materials"
+_citation_journal_volume        236
+_citation_page_first            293
+_citation_page_last             301
+_citation_article_id            .
+_citation_year                  2001
+_citation_DOI                   10.1016/s0304-8853(01)00463-2
+
+loop_
+_citation_author_name
+"S. Baran"
+"M. Hofmann"
+"G. Lampert"
+"N. Stusser"
+"A. Szytula"
+"D. Tobbens"
+"P. Smeibidl"
+"S. Kausche"
+
+
+
+
+
+_atomic_positions_source_database_code_ICSD  .
+_atomic_positions_source_other               .
+
+_transition_temperature     6
+_experiment_temperature     1.5
+
+loop_
+_irrep_id
+_irrep_dimension
+_irrep_small_dimension
+_irrep_direction_type
+_irrep_action
+_irrep_modes_number
+_irrep_presence
+mM2 3 1 . primary ? ?
+
+_exptl_crystal_magnetic_properties_details
+;
+NPD
+Magnetic moment Ho1: 6.7(7)
+magnetic moment transformations do not agree with those of the listed symmetry operations, due to the different a,b parameters
+;
+
+_active_magnetic_irreps_details
+;
+1k magnetic structure
+k-maximal magnetic symmetry (4 possible)
+;
+
+_parent_space_group.name_H-M_alt  'P  6_3m  c'
+_parent_space_group.IT_number                       186
+_parent_space_group.transform_Pp_abc  'a,b,c;0,0,0'
+
+loop_
+_parent_propagation_vector.id
+_parent_propagation_vector.kxkykz
+k1 [1/2 0 0]
+
+_parent_space_group.child_transform_Pp_abc  '2a,b,c;0,0,0'
+_space_group_magn.transform_BNS_Pp_abc  'a+b,b,c;0,0,0'
+
+
+_space_group_magn.number_BNS  33.154
+_space_group_magn.name_BNS  "P_C  n  a  2_1"
+_space_group_magn.point_group_name  "mm21'"
+_space_group_magn.point_group_number  "7.2.21"
+_cell_length_a                 8.80400
+_cell_length_b                 4.40200
+_cell_length_c                 7.20400
+_cell_angle_alpha              90.00
+_cell_angle_beta               90.00
+_cell_angle_gamma              120.00
+
+loop_
+_space_group_symop_magn_operation.id
+_space_group_symop_magn_operation.xyz
+1 x,y,z,+1
+2 -x+1/2,-2x+y,z+1/2,+1
+3 -x,-y,z+1/2,+1
+4 x+1/2,2x-y,z,+1
+
+loop_
+_space_group_symop_magn_centering.id
+_space_group_symop_magn_centering.xyz
+1 x,y,z,+1
+2 x+1/2,y,z,-1
+
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+Ho1 Ho 0.00000 0.00000 0.25000 1
+Au1 Au 0.16667 0.66667 0.040(25) 1
+Ge1 Ge 0.16667 0.66667 0.459(24) 1
+
+loop_
+_atom_site_moment.label
+_atom_site_moment.crystalaxis_x
+_atom_site_moment.crystalaxis_y
+_atom_site_moment.crystalaxis_z
+_atom_site_moment.symmform
+Ho1 -3.4 -1.7 6. 2my,my,mz

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -1096,6 +1096,23 @@ Gd1 5.05 5.05 0.0"""
 
         assert s_ncl.matches(s_ncl_from_msg)
 
+    def test_axial_moment_transform_non_orthogonal_cell(self):
+        # MAGNDATA 1.34 (HoAuGe): child cell of a hexagonal parent (a doubled, so
+        # a = 2b, gamma = 120 deg);
+        # symmetry operations containing -2x+y mix the unequal a/b axes. Regression
+        # test for unit-crystal-axis moments being rotated by the rotation matrix in
+        # crystallographic axes without rescaling by the axis lengths, which inflated |m| on the
+        # symmetry-expanded sites (gave 7.499 instead of 6.684 on two of them).
+        parser = CifParser(f"{MCIF_TEST_DIR}/magnetic.example.HoAuGe.mcif")
+        struct = parser.parse_structures(primitive=False)[0]
+        ho_moments = np.array([site.properties["magmom"].moment for site in struct if site.specie.symbol == "Ho"])
+        assert len(ho_moments) == 4
+        # asymmetric-unit moment (-3.4, -1.7, 6.0) in unit-crystal-axis components;
+        # |m| = sqrt(m.G.m) with the pure-cosine metric G (gamma = 120) = 6.6836 uB,
+        # and every image must keep that magnitude
+        norms = np.linalg.norm(ho_moments, axis=1)
+        assert norms == approx([6.6836] * 4, abs=1e-3)
+
     def test_write(self):
         with open(f"{MCIF_TEST_DIR}/GdB4-writer-ref.mcif", encoding="utf-8") as file:
             cw_ref_str = file.read()


### PR DESCRIPTION
## Summary

Fixes magnetic moments when `CifParser` expands symmetry-equivalent sites from *.mcif files whose magnetic cell has crystal axes of unequal length.

- `_atom_site_moment.crystalaxis_{x,y,z}` components are defined along **unit** crystal axes (per the [magCIF dictionary](https://www.iucr.org/resources/cif/dictionaries/cif_mag); development version at [COMCIFS/magnetic_dic](https://github.com/COMCIFS/magnetic_dic)), while `_space_group_symop_magn_operation.xyz` rotation matrices are expressed in **crystallographic axes** (acting on fractional coordinates).
- `CifParser._unique_coords` applied the crystallographic-axes rotation matrix directly to the unit-axis moment components as if both were in Cartesian coordinates. Whenever an operation mixes axes of unequal length, this changes the moment magnitude.
- This shows up e.g. in type-IV MSGs whose child cell doubles an axis of a hexagonal parent (giving `a = 2b`, `gamma = 120 deg`), such as MAGNDATA [1.34 (HoAuGe)](https://www.cryst.ehu.es/magndata/index.php?index=1.34): operations like `-x+1/2, -2x+y, z+1/2` mix the unequal a/b axes, and two of the four Ho images came back at 7.499 uB instead of 6.684 uB.
- The errors cancel for orthogonal equal-axis cells and signed-permutation operations, which is why the existing mcif test assets never tripped on it.

**Fix:** convert both the moment and the operation to Cartesian coordinates before applying `MagSymmOp.operate_magmom` (`rot_cart = M.T @ R @ inv(M.T)`, with `M` the row-vector lattice matrix), matching the `SymmOp` contract that rotation matrices act in Cartesian space.

Also includes a small chore commit fixing the pre-commit global exclude pattern (`test_files` -> also match the in-repo `test-files` fixture directory) so hooks stop running on ~2000 fixture files, and excluding `CHANGES.md` from codespell.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))