### PR TITLE
Re-allowing disordered Slabs

### DIFF
--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -165,7 +165,7 @@ class Slab(Structure):
 
             self.oriented_unit_cell = Structure(
                 ouc_lattice,
-                oriented_unit_cell.species,
+                oriented_unit_cell.species_and_occu,
                 oriented_unit_cell.frac_coords,
                 charge=oriented_unit_cell.charge,
                 coords_are_cartesian=False,

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose
 from pytest import approx
 
 import pymatgen.core
-from pymatgen.core import Lattice, Structure
+from pymatgen.core import Composition, Lattice, Structure
 from pymatgen.core.structure_matcher import StructureMatcher
 from pymatgen.core.surface import (
     ReconstructionGenerator,
@@ -658,6 +658,14 @@ class TestSlabGenerator(MatSciTest):
         # flag check and subsequent transformation of slabs.
         assert slabs[0].energy == approx(2.0)
         assert slabs[1].energy == approx(6.0)
+
+    def test_disordered_slab(self):
+        # Test that generation of a disordered Slab is possible
+        comp = Composition({"Na": 0.5, "K": 0.5})
+        struct = Structure([[1, 0, 0], [0, 1, 0], [0, 0, 1]], [comp],
+                           np.zeros((1, 3), dtype=np.float64))
+        slabs = SlabGenerator(struct, (0, 0, 1), 1, 0).get_slabs()
+        assert slabs[0].sites[0].species == comp
 
 
 class TestReconstructionGenerator(MatSciTest):

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -662,8 +662,7 @@ class TestSlabGenerator(MatSciTest):
     def test_disordered_slab(self):
         # Test that generation of a disordered Slab is possible
         comp = Composition({"Na": 0.5, "K": 0.5})
-        struct = Structure([[1, 0, 0], [0, 1, 0], [0, 0, 1]], [comp],
-                           np.zeros((1, 3), dtype=np.float64))
+        struct = Structure([[1, 0, 0], [0, 1, 0], [0, 0, 1]], [comp], np.zeros((1, 3), dtype=np.float64))
         slabs = SlabGenerator(struct, (0, 0, 1), 1, 0).get_slabs()
         assert slabs[0].sites[0].species == comp
 


### PR DESCRIPTION
Re-allows the generation of Slabs from disordered species, like before #24.
This isn't a new feature, but the OUC from #24 used .species instead of .species_and_occu, accidentally disallowing the generation of disordered Slabs.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))
